### PR TITLE
mutationCacheUpdates integration test fix

### DIFF
--- a/packages/offix-client/integration_test/test/offline.test.js
+++ b/packages/offix-client/integration_test/test/offline.test.js
@@ -319,7 +319,7 @@ describe('Offline mutations', function () {
 
       const response = await client.query({
         query: GET_TASKS,
-        fetchPolicy: 'network-only'
+        fetchPolicy: 'cache-first'
       });
 
       expect(response.data.allTasks).to.exist;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

The part of integration test for mutationCacheUpdates should check that cache was updated after client restarts. The tests passes now, but should actually do the check with `cache-first` query.

