### PR TITLE
fix: stop using hardcoded id field for operations.

### DIFF
--- a/packages/offix-cache/src/cache/mutations.ts
+++ b/packages/offix-cache/src/cache/mutations.ts
@@ -122,7 +122,7 @@ export const createMutationOptions = <T = {
     options.update = update;
   }
 
-  options.context = { ...context, returnType };
+  options.context = { ...context, returnType, idField };
   return options;
 };
 

--- a/packages/offix-offline/src/conflicts/BaseLink.ts
+++ b/packages/offix-offline/src/conflicts/BaseLink.ts
@@ -35,7 +35,8 @@ export class BaseLink extends ApolloLink {
   }
 
   private processBaseState(operation: Operation, forward: NextLink): Observable<FetchResult> {
-    const conflictBase = getObjectFromCache(operation, operation.variables.id);
+    const idField = operation.getContext().idField || "id";
+    const conflictBase = getObjectFromCache(operation, operation.variables[idField]);
     if (conflictBase && Object.keys(conflictBase).length !== 0) {
       if (this.stater.hasConflict(operation.variables, conflictBase)) {
         // 🙊 Input data is conflicted with the latest server projection

--- a/packages/offix-offline/src/offline/OperationQueueEntry.ts
+++ b/packages/offix-offline/src/offline/OperationQueueEntry.ts
@@ -9,6 +9,7 @@ export interface OfflineItem {
   id: string;
   conflictBase?: any;
   returnType?: string;
+  idField?: string;
   optimisticResponse?: any;
   conflictStrategy?: string;
 }
@@ -22,6 +23,7 @@ export class OperationQueueEntry implements OfflineItem {
   public readonly operation: Operation;
   public readonly optimisticResponse?: any;
   public readonly id: string;
+  public readonly idField?: string = "id";
   public readonly returnType?: string;
   public readonly conflictBase: any;
   public conflictStrategy?: string;
@@ -43,6 +45,7 @@ export class OperationQueueEntry implements OfflineItem {
       const context = operation.getContext();
       this.conflictBase = context.conflictBase;
       this.returnType = context.returnType;
+      this.idField = context.idField;
       this.optimisticResponse = context.optimisticResponse;
       if (context.conflictStrategy) {
         this.conflictStrategy = context.conflictStrategy.id;
@@ -55,7 +58,7 @@ export class OperationQueueEntry implements OfflineItem {
    * For new items made when offline changes will always have client side id.
    */
   public hasClientId() {
-    return isClientGeneratedId(this.operation.variables.id);
+    return isClientGeneratedId(this.operation.variables[this.idField as string]);
   }
 
   /**
@@ -66,6 +69,7 @@ export class OperationQueueEntry implements OfflineItem {
       operation: this.operation,
       optimisticResponse: this.optimisticResponse,
       id: this.id,
+      idField: this.idField,
       returnType: this.returnType,
       conflictBase: this.conflictBase,
       conflictStrategy: this.conflictStrategy

--- a/packages/offix-offline/src/offline/processors/IDProcessor.ts
+++ b/packages/offix-offline/src/offline/processors/IDProcessor.ts
@@ -17,22 +17,24 @@ export class IDProcessor implements IResultProcessor {
       return;
     }
     const { operation: { operationName }, optimisticResponse } = entry;
+    const idField = entry.idField || "id";
+
     if (!result ||
       !optimisticResponse ||
       !optimisticResponse[operationName]) {
       return;
     }
 
-    let clientId = optimisticResponse[operationName].id;
+    let clientId = optimisticResponse[operationName][idField];
     if (!clientId) {
       return;
     }
     // Ensure we dealing with string
     clientId = clientId.toString();
-    if (isClientGeneratedId(optimisticResponse[operationName].id)) {
+    if (isClientGeneratedId(optimisticResponse[operationName][idField])) {
       queue.forEach(({ operation: op }) => {
-        if (op.variables.id === clientId) {
-          op.variables.id = result.data && result.data[operationName].id;
+        if (op.variables[idField] === clientId) {
+          op.variables[idField] = result.data && result.data[operationName][idField];
         }
       });
     }


### PR DESCRIPTION
this commit fixes a problem where we assume id is the unique
field for an object. to fix this i have used the idField which
we already have available. if it is not provided in context then
we revert to the default of "id"

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [ ] documentation is changed or added
