### PR TITLE
Make WebsocketLink headers work the same as AuthLink

### DIFF
--- a/packages/offix-client/src/auth/AuthContextProvider.ts
+++ b/packages/offix-client/src/auth/AuthContextProvider.ts
@@ -1,9 +1,19 @@
 /**
- * Contains header and auth token information that can be supplied to graphql requests
+ * Contains header information that can be supplied to graphql requests.
+ * E.g.:
+ * 
+ * ```
+ *  {
+ *    headers: {
+ *      Authorization: 'Bearer 123...'
+ *    }
+ *  }
+ * ```
  */
 export interface AuthContext {
-  header: any;
-  token: string;
+  headers: {
+    [headerName: string]: any
+  }
 }
 
 /**

--- a/packages/offix-client/src/auth/AuthContextProvider.ts
+++ b/packages/offix-client/src/auth/AuthContextProvider.ts
@@ -1,7 +1,7 @@
 /**
  * Contains header information that can be supplied to graphql requests.
  * E.g.:
- * 
+ *
  * ```
  *  {
  *    headers: {
@@ -13,7 +13,7 @@
 export interface AuthContext {
   headers: {
     [headerName: string]: any
-  }
+  };
 }
 
 /**

--- a/packages/offix-client/src/links/AuthLink.ts
+++ b/packages/offix-client/src/links/AuthLink.ts
@@ -5,9 +5,9 @@ import { OffixClientConfig } from "../config/OffixClientConfig";
 export const createAuthLink = (config: OffixClientConfig): ApolloLink => {
   const asyncHeadersLink = setContext(async (operation, previousContext) => {
     if (config.authContextProvider) {
-      const { header } = await config.authContextProvider();
+      const { headers } = await config.authContextProvider();
       return {
-        headers: header
+        headers
       };
     }
   });

--- a/packages/offix-client/src/links/WebsocketLink.ts
+++ b/packages/offix-client/src/links/WebsocketLink.ts
@@ -10,7 +10,9 @@ export const defaultWebSocketLink = (userOptions: OffixClientConfig, config: Web
       connectionParams: async () => {
         if (userOptions.authContextProvider) {
           const { header } = await userOptions.authContextProvider();
-          return { Authorization: header };
+          return {
+            headers: header
+          };
         }
       },
       connectionCallback: options.connectionCallback,

--- a/packages/offix-client/src/links/WebsocketLink.ts
+++ b/packages/offix-client/src/links/WebsocketLink.ts
@@ -9,9 +9,9 @@ export const defaultWebSocketLink = (userOptions: OffixClientConfig, config: Web
       // Params that can be used to send authentication token etc.
       connectionParams: async () => {
         if (userOptions.authContextProvider) {
-          const { header } = await userOptions.authContextProvider();
+          const { headers } = await userOptions.authContextProvider();
           return {
-            headers: header
+            headers
           };
         }
       },


### PR DESCRIPTION
### Description

Before this change, the function was returning an object of the type `{ Authorization: any }`, which is incompatible with what is expected from `connectionParams`. This change uses the same methods as they are used on AuthLink.

Tests are not passing but it seems to be unrelated to this change (errors come from `CacheHelpersTest.ts`)

##### Checklist

- [ ] `npm test` passes
- [x] `npm run build` works