### PR TITLE
Do not require cache updates without app restart

### DIFF
--- a/docs/ref-release-notes.md
+++ b/docs/ref-release-notes.md
@@ -1,5 +1,12 @@
 ## What is new in Offix
 
+### 0.8.0 
+
+#### Offline operations persist optimistic response
+
+Offline operations will now cache update functional and automatically apply optimistic response
+`OffixClientConfig.mutationCacheUpdates` is still required to see optimistic responses after application restart.
+
 ### 0.7.0 
 
 #### Support Apollo 2.6.x

--- a/packages/offix-client/integration_test/test/cache.test.js
+++ b/packages/offix-client/integration_test/test/cache.test.js
@@ -170,7 +170,7 @@ describe("Offline cache and mutations", () => {
       assertTaskEqualTaskTemplate(response.data.allTasks[0]);
     });
 
-    it.skip('query tasks while online, go offline, create task and query tasks again using updateQuery', async function () {
+    it('query tasks while online, go offline, create task and query tasks again using updateQuery', async function () {
 
       const { client, networkStatus: network } = await newClient()
 

--- a/packages/offix-client/src/OfflineClient.ts
+++ b/packages/offix-client/src/OfflineClient.ts
@@ -105,10 +105,10 @@ export class OfflineClient implements ListenerProvider {
     if (!this.apolloClient) {
       throw new Error("Apollo offline client not initialised before mutation called.");
     } else {
-      const helperOptions = createMutationOptions<T, TVariables>(options);
-      helperOptions.context.updateFunction = helperOptions.update;
+      const mutationOptions = createMutationOptions<T, TVariables>(options);
+      mutationOptions.context.updateFunction = mutationOptions.update;
       return this.apolloClient.mutate<T, TVariables>(
-        helperOptions
+        mutationOptions
       );
     }
   }

--- a/packages/offix-client/src/OfflineClient.ts
+++ b/packages/offix-client/src/OfflineClient.ts
@@ -105,8 +105,10 @@ export class OfflineClient implements ListenerProvider {
     if (!this.apolloClient) {
       throw new Error("Apollo offline client not initialised before mutation called.");
     } else {
+      const helperOptions = createMutationOptions<T, TVariables>(options);
+      helperOptions.context.updateFunction = helperOptions.update;
       return this.apolloClient.mutate<T, TVariables>(
-        createMutationOptions<T, TVariables>(options)
+        helperOptions
       );
     }
   }


### PR DESCRIPTION
## Motivation

Global cache updates are required now to see optimistic response on every offline mutation. This change will allow us to use context attached cache update. 

Documentation is still valid, this will be just a major usability feature that will let us to experiment with sample apps without unexpected behavior.
