### PR TITLE
fix: ensure mutation result is returned from watchOfflineChange

### DIFF
--- a/packages/offix-offline/src/offline/OfflineError.ts
+++ b/packages/offix-offline/src/offline/OfflineError.ts
@@ -21,7 +21,7 @@ export class OfflineError {
     this.offlineMutationPromise = offlineMutationPromise;
   }
 
-  public async watchOfflineChange(): Promise<any> {
-    await this.offlineMutationPromise;
+  public watchOfflineChange(): Promise<any> {
+    return this.offlineMutationPromise;
   }
 }

--- a/packages/offix-offline/src/offline/OfflineMutationsHandler.ts
+++ b/packages/offix-offline/src/offline/OfflineMutationsHandler.ts
@@ -45,7 +45,7 @@ export class OfflineMutationsHandler {
    *
    * @param item
    */
-  public async mutateOfflineElement(item: OfflineItem) {
+  public mutateOfflineElement(item: OfflineItem) {
     const optimisticResponse = item.optimisticResponse;
     const mutationName = getMutationName(item.operation.query);
     let updateFunction;
@@ -67,7 +67,7 @@ export class OfflineMutationsHandler {
       // Pass extensions as part of the context
       context: { ...previousContext, ...newContext }
     };
-    await this.apolloClient.mutate(mutationOptions);
+    return this.apolloClient.mutate(mutationOptions);
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

What I discovered is this issue:

```
client.mutate(...).catch((error)=> {
  if(error.networkError && error.networkError.offline){
    const offlineError =  error.networkError;
    offlineError.watchOfflineChange().then((result) => {
      console.log(result) // result is always undefined
    })
  }
});
```

Working on a test now.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
