### PR TITLE
fix: catch errors when adding to offline queue

### DIFF
--- a/packages/offix-offline/src/offline/OfflineLink.ts
+++ b/packages/offix-offline/src/offline/OfflineLink.ts
@@ -65,6 +65,8 @@ export class OfflineLink extends ApolloLink {
         const offlineMutation = handler.mutateOfflineElement(operationEntry);
         logger("Returning offline error to client", operation.variables);
         observer.error(new OfflineError(offlineMutation));
+      }).catch((error) => {
+        logger("Error occurred when persisting item to offline queue", error);
       });
       return () => { return; };
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

When adding items to the offline queue we currently do nothing if an error occurs. This can happen for a number of reasons. One being if the storage is not ready or if the cache quota is exceeded.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
