### PR TITLE
feat: add httpOptions to init()

### DIFF
--- a/packages/offix-client/src/OfflineClient.ts
+++ b/packages/offix-client/src/OfflineClient.ts
@@ -12,8 +12,9 @@ import {
 } from "offix-offline";
 import { ApolloOfflineClient } from "./ApolloOfflineClient";
 import { MutationHelperOptions, createMutationOptions } from "offix-cache";
-import { FetchResult } from "apollo-link";
+import { ApolloLink,FetchResult } from "apollo-link";
 import { buildCachePersistence } from "./cache";
+import { HttpLink } from "apollo-link-http";
 
 /**
 * Factory for creating Apollo Offline Client
@@ -60,13 +61,12 @@ export class OfflineClient implements ListenerProvider {
   /**
   * Initialize client
   */
-  public async init(): Promise<ApolloOfflineClient> {
+  public async init(httpOptions?: HttpLink.Options): Promise<ApolloOfflineClient> {
     await this.store.init();
     const cache = await buildCachePersistence(this.config.cacheStorage);
     const offlineLink = await createOfflineLink(this.config, this.store);
     const conflictLink = await createConflictLink(this.config);
-    const link = await createDefaultLink(this.config, offlineLink, conflictLink, cache);
-
+    const link = await createDefaultLink(this.config, offlineLink, conflictLink, cache, httpOptions);
     const client = new ApolloClient({
       link,
       cache

--- a/packages/offix-client/src/OfflineClient.ts
+++ b/packages/offix-client/src/OfflineClient.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, MutationOptions, OperationVariables } from "apollo-client";
+import { ApolloClient, OperationVariables } from "apollo-client";
 import { OffixClientConfig } from "./config";
 import { OffixDefaultConfig } from "./config/OffixDefaultConfig";
 import { createDefaultLink, createOfflineLink, createConflictLink } from "./links/LinksBuilder";
@@ -12,9 +12,8 @@ import {
 } from "offix-offline";
 import { ApolloOfflineClient } from "./ApolloOfflineClient";
 import { MutationHelperOptions, createMutationOptions } from "offix-cache";
-import { ApolloLink,FetchResult } from "apollo-link";
+import { FetchResult } from "apollo-link";
 import { buildCachePersistence } from "./cache";
-import { HttpLink } from "apollo-link-http";
 
 /**
 * Factory for creating Apollo Offline Client
@@ -61,12 +60,12 @@ export class OfflineClient implements ListenerProvider {
   /**
   * Initialize client
   */
-  public async init(httpOptions?: HttpLink.Options): Promise<ApolloOfflineClient> {
+  public async init(): Promise<ApolloOfflineClient> {
     await this.store.init();
     const cache = await buildCachePersistence(this.config.cacheStorage);
     const offlineLink = await createOfflineLink(this.config, this.store);
     const conflictLink = await createConflictLink(this.config);
-    const link = await createDefaultLink(this.config, offlineLink, conflictLink, cache, httpOptions);
+    const link = await createDefaultLink(this.config, offlineLink, conflictLink, cache);
     const client = new ApolloClient({
       link,
       cache

--- a/packages/offix-client/src/config/OffixClientConfig.ts
+++ b/packages/offix-client/src/config/OffixClientConfig.ts
@@ -7,6 +7,7 @@ import { ObjectState } from "offix-offline";
 import { ConflictListener } from "offix-offline";
 import { CacheUpdates } from "offix-cache";
 import { RetryLink } from "apollo-link-retry";
+import { HttpLink } from "apollo-link-http";
 
 /**
  * Contains all configuration options required to initialize Voyager Client
@@ -100,4 +101,12 @@ export interface OffixClientConfig {
    *
    */
   retryOptions?: RetryLink.Options;
+
+  /**
+   * [Modifier]
+   *
+   * The options to configure HttpLink and/or the file upload link.
+   *
+   */
+  httpLinkOptions?: HttpLink.Options;
 }

--- a/packages/offix-client/src/config/OffixClientConfig.ts
+++ b/packages/offix-client/src/config/OffixClientConfig.ts
@@ -9,10 +9,6 @@ import { CacheUpdates } from "offix-cache";
 import { RetryLink } from "apollo-link-retry";
 import { HttpLink } from "apollo-link-http";
 
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
-export type HttpLinkOptions = Omit<HttpLink.Options, "uri">;
-
 /**
  * Contains all configuration options required to initialize Voyager Client
  * Options marked with [Modifier] flag are used to modify behavior of client.
@@ -112,5 +108,5 @@ export interface OffixClientConfig {
    * The options to configure HttpLink and/or the file upload link.
    *
    */
-  httpLinkOptions?: HttpLinkOptions;
+  httpLinkOptions?: HttpLink.Options;
 }

--- a/packages/offix-client/src/config/OffixClientConfig.ts
+++ b/packages/offix-client/src/config/OffixClientConfig.ts
@@ -9,6 +9,10 @@ import { CacheUpdates } from "offix-cache";
 import { RetryLink } from "apollo-link-retry";
 import { HttpLink } from "apollo-link-http";
 
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export type HttpLinkOptions = Omit<HttpLink.Options, "uri">;
+
 /**
  * Contains all configuration options required to initialize Voyager Client
  * Options marked with [Modifier] flag are used to modify behavior of client.
@@ -108,5 +112,5 @@ export interface OffixClientConfig {
    * The options to configure HttpLink and/or the file upload link.
    *
    */
-  httpLinkOptions?: HttpLink.Options;
+  httpLinkOptions?: HttpLinkOptions;
 }

--- a/packages/offix-client/src/links/LinksBuilder.ts
+++ b/packages/offix-client/src/links/LinksBuilder.ts
@@ -88,10 +88,9 @@ export const defaultHttpLinks = async (config: OffixClientConfig, offlineLink: A
   const localFilterLink = new LocalDirectiveFilterLink();
   links.push(localFilterLink);
 
-  const httpLinkOptions = {
-    uri: config.httpUrl,
-    ...config.httpLinkOptions
-  };
+  const httpLinkOptions = config.httpLinkOptions ? config.httpLinkOptions : {};
+
+  httpLinkOptions.uri = config.httpUrl;
 
   if (config.fileUpload) {
     links.push(createUploadLink(httpLinkOptions));

--- a/packages/offix-client/src/links/LinksBuilder.ts
+++ b/packages/offix-client/src/links/LinksBuilder.ts
@@ -26,8 +26,8 @@ import { BaseLink } from "offix-offline";
  * - File uploads
  */
 export const createDefaultLink = async (config: OffixClientConfig, offlineLink: ApolloLink,
-                                        conflictLink: ApolloLink, cache: InMemoryCache, httpOptions: HttpLink.Options) => {
-  let link = await defaultHttpLinks(config, offlineLink, conflictLink, cache, httpOptions);
+                                        conflictLink: ApolloLink, cache: InMemoryCache) => {
+  let link = await defaultHttpLinks(config, offlineLink, conflictLink, cache);
   if (config.wsUrl) {
     const wsLink = defaultWebSocketLink(config, { uri: config.wsUrl });
     link = ApolloLink.split(isSubscription, wsLink, link);
@@ -70,7 +70,7 @@ export const createConflictLink = async (config: OffixClientConfig) => {
  * - Audit logging
  */
 export const defaultHttpLinks = async (config: OffixClientConfig, offlineLink: ApolloLink,
-                                       conflictLink: ApolloLink, cache: InMemoryCache, httpOptions: HttpLink.Options): Promise<ApolloLink> => {
+                                       conflictLink: ApolloLink, cache: InMemoryCache): Promise<ApolloLink> => {
 
   // Enable offline link only for mutations and onlineOnly
   const mutationOfflineLink = ApolloLink.split((op: Operation) => {
@@ -81,7 +81,7 @@ export const defaultHttpLinks = async (config: OffixClientConfig, offlineLink: A
   links.push(conflictLink);
   const retryLink = ApolloLink.split(OfflineMutationsHandler.isMarkedOffline, new RetryLink(config.retryOptions));
   links.push(retryLink);
-  
+
   if (config.authContextProvider) {
     links.push(createAuthLink(config));
   }
@@ -90,8 +90,8 @@ export const defaultHttpLinks = async (config: OffixClientConfig, offlineLink: A
 
   const httpLinkOptions = {
     uri: config.httpUrl,
-    ...httpOptions
-  }
+    ...config.httpLinkOptions
+  };
 
   if (config.fileUpload) {
     links.push(createUploadLink(httpLinkOptions));


### PR DESCRIPTION
We have implemented Offix to our chat-app and problem we have is that Offix does not support credentials in http links. Below are our initial proposed changes. Let us know what do you think! 

