### PR TITLE
feat: make OfflineClient.apolloClient public

### DIFF
--- a/docs/ref-release-notes.md
+++ b/docs/ref-release-notes.md
@@ -1,5 +1,23 @@
 ## What is new in Offix
 
+# Unreleased
+
+# Fixed
+
+*
+
+# Added
+
+* `OfflineClient.apolloClient` is now public. This means `apolloClient` is directly accessible after `OfflineClient.init()`.
+
+# Changed
+
+*
+
+# Removed
+
+* 
+
 ### 0.7.1
 
 #### Offline operations persist optimistic response

--- a/packages/offix-client/src/OfflineClient.ts
+++ b/packages/offix-client/src/OfflineClient.ts
@@ -47,7 +47,7 @@ export const createClient = async (userConfig: OffixClientConfig):
 export class OfflineClient implements ListenerProvider {
 
   public queueListeners: OfflineQueueListener[] = [];
-  private apolloClient?: ApolloOfflineClient;
+  public apolloClient?: ApolloOfflineClient;
   private store: OfflineStore;
   private config: OffixDefaultConfig;
 

--- a/packages/offix-client/test/OfflineClientTest.ts
+++ b/packages/offix-client/test/OfflineClientTest.ts
@@ -25,6 +25,12 @@ describe("Top level api tests", () => {
     should().exist(client.registerOfflineEventListener);
   });
 
+  it("apolloClient should be available after init", async () => {
+    const client = new OfflineClient({ httpUrl: url, storage, networkStatus });
+    await client.init();
+    should().exist(client.apolloClient);
+  });
+
   it("Apply listener", async () => {
     const client = new OfflineClient({ httpUrl: url, storage, networkStatus });
     const initClient = await client.init();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

Make the apollo client accessible on the OfflineClient class. This drastically simplifies how the client can be accessed within different contexts across applications.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
