### PR TITLE
Check if dealing with JSON or Operation object in persistent queue

### DIFF
--- a/packages/offix-offline/src/offline/OfflineMutationsHandler.ts
+++ b/packages/offix-offline/src/offline/OfflineMutationsHandler.ts
@@ -50,11 +50,15 @@ export class OfflineMutationsHandler {
     const mutationName = getMutationName(item.operation.query);
     let context;
     let updateFunction;
+    let previousContext: any = {};
 
-    const previousContext = item.operation.getContext();
-    if (previousContext.updateFunction) {
-      updateFunction = previousContext.updateFunction;
+    if (item.operation.getContext) {
+      previousContext = item.operation.getContext();
+      if (previousContext.updateFunction) {
+        updateFunction = previousContext.updateFunction;
+      }
     }
+
     context = { ...previousContext, ...this.getOfflineContext(item) };
 
     if (this.mutationCacheUpdates && mutationName) {


### PR DESCRIPTION
OfflineMutationsHandler will deal with two types of elements:

- Elements enqueued instantly after scheduling
- Element enqueued after restart

Second option is missing function calls and we should always check if they exist.

## Verification

1. Go offline
2. Add some tasks
3. Restart website when online 
4. See no error from #145