### PR TITLE
migrate tests for offix-conflicts-server from ava to jest

### DIFF
--- a/packages/offix-conflicts-server/jest.config.js
+++ b/packages/offix-conflicts-server/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    "roots": [
+      "<rootDir>/test"
+    ],
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+  }

--- a/packages/offix-conflicts-server/package.json
+++ b/packages/offix-conflicts-server/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "build": "tsc --build tsconfig.json",
         "watch": "tsc --build tsconfig.json --watch",
-        "test": "ava",
+        "test": "jest",
         "compile:clean": "tsc --build tsconfig.json --clean"
     },
     "license": "Apache-2.0",
@@ -14,21 +14,12 @@
         "type": "git",
         "url": "git+https://github.com/aerogear/offix.git"
     },
-    "ava": {
-        "compileEnhancements": false,
-        "extensions": [
-            "ts"
-        ],
-        "require": [
-            "ts-node/register"
-        ],
-        "files": [
-            "./test/**/*.test.ts"
-        ]
-    },
     "devDependencies": {
-        "ava": "2.4.0",
+        "@types/jest": "^24.0.18",
+        "@types/node": "^12.7.12",
         "graphql": "14.5.8",
+        "jest": "^24.9.0",
+        "ts-jest": "^24.1.0",
         "ts-node": "8.4.1",
         "typescript": "3.6.3"
     },

--- a/packages/offix-conflicts-server/test/HashObjectState.test.ts
+++ b/packages/offix-conflicts-server/test/HashObjectState.test.ts
@@ -1,11 +1,9 @@
-import test from "ava";
 import { HashObjectState } from "../src/states/HashObjectState";
 
-test("With conflict", (t) => {
+test("With conflict", () => {
   const hashMethod = (data: any) => JSON.stringify(data);
   const objectState = new HashObjectState(hashMethod);
   const serverData = { name: "AeroGear", ignoredProperty: "test", version: 1 };
   const clientData = { name: "Red Hat", version: 1};
-  t.true(objectState.checkForConflict(serverData, clientData) !==  undefined);
-
+  expect(objectState.checkForConflict(serverData, clientData)).not.toBe(undefined);
 });

--- a/packages/offix-conflicts-server/test/VersionedObjectState.test.ts
+++ b/packages/offix-conflicts-server/test/VersionedObjectState.test.ts
@@ -1,28 +1,25 @@
-import test from "ava";
 import { VersionedObjectState } from "../src/states/VersionedObjectState";
 
-test("With conflict", (t) => {
+test("With conflict", () => {
   const objectState = new VersionedObjectState();
   const serverData = { name: "AeroGear", version: 1 };
   const clientData = { name: "Red Hat", version: 2 };
-  t.true(objectState.checkForConflict(serverData, clientData) !==  undefined);
+  expect(objectState.checkForConflict(serverData, clientData)).not.toBe(undefined);
 });
 
-test("Without conflict", (t) => {
+test("Without conflict", () => {
   const objectState = new VersionedObjectState();
   const serverData = { name: "AeroGear", version: 1 };
   const clientData = { name: "AeroGear", version: 1 };
 
-  t.true(objectState.checkForConflict(serverData, clientData) === undefined);
-  t.deepEqual(clientData.version, 2);
+  expect(objectState.checkForConflict(serverData, clientData)).toBe(undefined);
+  expect(clientData.version).toBe(2);
 });
 
-test("Missing version", (t) => {
+test("Missing version", () => {
   const objectState = new VersionedObjectState();
   const serverData = { name: "AeroGear" };
   const clientData = { name: "AeroGear", version: 1 };
 
-  t.throws(() => {
-    objectState.checkForConflict(serverData, clientData);
-  });
+  expect(() => objectState.checkForConflict(serverData, clientData)).toThrow();
 });


### PR DESCRIPTION
### Description

- migrate tests for offix-conflicts-server from ava to jest

##### Checklist

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
