### PR TITLE
Presistor options

### DIFF
--- a/docs/ref-configuration.md
+++ b/docs/ref-configuration.md
@@ -39,7 +39,7 @@ const client = new ApolloOfflineClient({
 });
 ```
 
-Note: if using TypeScript, you may need to declare the cachePersistor as follows `const cachePersistor = new CachePersistor<NormalizedCacheObject>(...options)` or you may experience compiler errors.
+Note: if using TypeScript, you may need to declare the cachePersistor as follows `const cachePersistor = new CachePersistor<object>(...options)` or you may experience compiler errors.
 
 This example uses `createDefaultCacheStorage` to create the default IndexedDB based storage driver. 
 The storage can be swapped depending on the platform. For example `window.localstorage` in older browsers or `AsyncStorage` in [React Native](./react-native.md).

--- a/docs/ref-configuration.md
+++ b/docs/ref-configuration.md
@@ -12,14 +12,67 @@ sidebar_label: Client Configuration
 
 There are some additional options specific to `ApolloOfflineClient`.
 
-* `cacheStorage` - The [PersistentStore](https://github.com/aerogear/offix/blob/master/packages/offix-scheduler/src/store/PersistentStore.ts) you want your client to use for persisting the Apollo Cache (Uses indexeddb by default).
-* `offlineStorage` - The [PersistentStore](https://github.com/aerogear/offix/blob/master/packages/offix-scheduler/src/store/PersistentStore.ts) you want your client to use for persisting offline operations in the offline queue (Uses indexeddb by default).
-* `networkStatus` - [NetworkStatus](https://github.com/aerogear/offix/blob/master/packages/offix-offline/src/network/NetworkStatus.ts) Interface for detecting changes in network status. (Uses browser networking APIs by default)
-* `offlineQueueListener` - [ApolloOfflineQueueListener](./ref-offline.md#listening-for-events) User provided listener that contains a set of methods that are called when certain events occur in the queue.
-* `conflictProvider` - [ObjectState](./ref-conflict-server.md#implementing-custom-conflict-resolution) Interface that defines how object state is progressed. This interface needs to match state provider supplied on server.
-* `conflictStrategy` - [ConflictResolutionStrategy](https://github.com/aerogear/offix/blob/master/packages/offix-conflicts-client/src/strategies/ConflictResolutionStrategy.ts)interface used on the client to resolve conflicts. The [default strategy](https://github.com/aerogear/offix/blob/master/packages/offix-conflicts-client/src/strategies/strategies.ts) merges client changes onto the server changes.
-* `mutationCacheUpdates` - [CacheUpdates](./ref-offline.md#global-update-functions) Cache updates functions for your mutations. Argument allows to restore optimistic responses on application restarts.
-* `retryOptions` - The options to configure how failed offline mutations are retried. See [`apollo-link-retry`](https://www.apollographql.com/docs/link/links/retry/).
+#### `cachePersistor`
+
+The [CachePersistor](https://github.com/apollographql/apollo-cache-persist#using-cachepersistor) instance used by the client to persist the Apollo Cache across application restarts. Pass your own instance to override the one that is created by default.
+
+Example:
+
+```js
+import { ApolloOfflineClient, createDefaultCacheStorage } from "offix-client";
+import { HttpLink } from "apollo-link-http";
+import { InMemoryCache } from "apollo-cache-inmemory";
+import { CachePersistor } from "apollo-cache-persist";
+
+const link = new HttpLink({ uri: "http://test" });
+const cache = new InMemoryCache()
+
+const cachePersistor = new CachePersistor<NormalizedCacheObject>({
+  cache,
+  storage: createDefaultCacheStorage()
+})
+
+const client = new ApolloOfflineClient({
+  cache,
+  cachePersistor,
+  link
+});
+```
+
+This example uses `createDefaultCacheStorage` to create the default IndexedDB based storage driver. 
+The storage can be swapped depending on the platform. For example `window.localstorage` in older browsers or `AsyncStorage` in [React Native](./react-native.md).
+
+#### `cacheStorage`
+
+The [PersistentStore](https://github.com/aerogear/offix/blob/master/packages/offix-scheduler/src/store/PersistentStore.ts) you want your client to use for persisting the Apollo Cache (Uses IndexedDB by default).
+
+#### `offlineStorage`
+
+The [PersistentStore](https://github.com/aerogear/offix/blob/master/packages/offix-scheduler/src/store/PersistentStore.ts) you want your client to use for persisting offline operations in the offline queue (Uses IndexedDB by default).
+
+#### `networkStatus`
+
+[NetworkStatus](https://github.com/aerogear/offix/blob/master/packages/offix-offline/src/network/NetworkStatus.ts) Interface for detecting changes in network status. (Uses browser networking APIs by default)
+
+#### `offlineQueueListener`
+
+[ApolloOfflineQueueListener](./ref-offline.md#listening-for-events) User provided listener that contains a set of methods that are called when certain events occur in the queue.
+
+#### `conflictProvider`
+
+[ObjectState](./ref-conflict-server.md#implementing-custom-conflict-resolution) Interface that defines how object state is progressed. This interface needs to match state provider supplied on server.
+
+#### `conflictStrategy`
+
+[ConflictResolutionStrategy](https://github.com/aerogear/offix/blob/master/packages/offix-conflicts-client/src/strategies/ConflictResolutionStrategy.ts)interface used on the client to resolve conflicts. The [default strategy](https://github.com/aerogear/offix/blob/master/packages/offix-conflicts-client/src/strategies/strategies.ts) merges client changes onto the server changes.
+
+#### `mutationCacheUpdates`
+
+[CacheUpdates](./ref-offline.md#global-update-functions) Cache updates functions for your mutations. Argument allows to restore optimistic responses on application restarts.
+
+#### `retryOptions`
+
+The options to configure how failed offline mutations are retried. See [`apollo-link-retry`](https://www.apollographql.com/docs/link/links/retry/).
 
 ## offix-client-boost
 

--- a/docs/ref-configuration.md
+++ b/docs/ref-configuration.md
@@ -24,10 +24,10 @@ import { HttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import { CachePersistor } from "apollo-cache-persist";
 
-const link = new HttpLink({ uri: "http://test" });
+const link = new HttpLink({ uri: "http://example.com/graphql" });
 const cache = new InMemoryCache()
 
-const cachePersistor = new CachePersistor<NormalizedCacheObject>({
+const cachePersistor = new CachePersistor({
   cache,
   storage: createDefaultCacheStorage()
 })
@@ -38,6 +38,8 @@ const client = new ApolloOfflineClient({
   link
 });
 ```
+
+Note: if using TypeScript, you may need to declare the cachePersistor as follows `const cachePersistor = new CachePersistor<NormalizedCacheObject>(...options)` or you may experience compiler errors.
 
 This example uses `createDefaultCacheStorage` to create the default IndexedDB based storage driver. 
 The storage can be swapped depending on the platform. For example `window.localstorage` in older browsers or `AsyncStorage` in [React Native](./react-native.md).

--- a/docs/ref-configuration.md
+++ b/docs/ref-configuration.md
@@ -12,6 +12,18 @@ sidebar_label: Client Configuration
 
 There are some additional options specific to `ApolloOfflineClient`.
 
+#### `networkStatus`
+
+[NetworkStatus](https://github.com/aerogear/offix/blob/master/packages/offix-offline/src/network/NetworkStatus.ts) Interface for detecting changes in network status. (Uses browser networking APIs by default)
+
+#### `offlineStorage`
+
+The [PersistentStore](https://github.com/aerogear/offix/blob/master/packages/offix-scheduler/src/store/PersistentStore.ts) you want your client to use for persisting offline operations in the offline queue (Uses IndexedDB by default).
+
+#### `cacheStorage`
+
+The [PersistentStore](https://github.com/aerogear/offix/blob/master/packages/offix-scheduler/src/store/PersistentStore.ts) you want your client to use for persisting the Apollo Cache (Uses IndexedDB by default).
+
 #### `cachePersistor`
 
 The [CachePersistor](https://github.com/apollographql/apollo-cache-persist#using-cachepersistor) instance used by the client to persist the Apollo Cache across application restarts. Pass your own instance to override the one that is created by default.
@@ -44,17 +56,6 @@ Note: if using TypeScript, you may need to declare the cachePersistor as follows
 This example uses `createDefaultCacheStorage` to create the default IndexedDB based storage driver. 
 The storage can be swapped depending on the platform. For example `window.localstorage` in older browsers or `AsyncStorage` in [React Native](./react-native.md).
 
-#### `cacheStorage`
-
-The [PersistentStore](https://github.com/aerogear/offix/blob/master/packages/offix-scheduler/src/store/PersistentStore.ts) you want your client to use for persisting the Apollo Cache (Uses IndexedDB by default).
-
-#### `offlineStorage`
-
-The [PersistentStore](https://github.com/aerogear/offix/blob/master/packages/offix-scheduler/src/store/PersistentStore.ts) you want your client to use for persisting offline operations in the offline queue (Uses IndexedDB by default).
-
-#### `networkStatus`
-
-[NetworkStatus](https://github.com/aerogear/offix/blob/master/packages/offix-offline/src/network/NetworkStatus.ts) Interface for detecting changes in network status. (Uses browser networking APIs by default)
 
 #### `offlineQueueListener`
 

--- a/docs/ref-offline.md
+++ b/docs/ref-offline.md
@@ -8,7 +8,7 @@ Offix provides first class support for performing GraphQL operations while offli
 
 Offix-client offers a comprehensive set of features to perform data operations when offline. Thanks to the offline mutation store users can stage their changes to be replicated back to the server when they return online.
 
-Please follow chapters bellow for more information.
+Please follow chapters below for more information.
 
 ## Querying local cache
 

--- a/packages/offix-client/src/ApolloOfflineClient.ts
+++ b/packages/offix-client/src/ApolloOfflineClient.ts
@@ -49,13 +49,20 @@ export class ApolloOfflineClient extends ApolloClient<NormalizedCacheObject> {
     this.mutationCacheUpdates = config.mutationCacheUpdates;
     this.conflictProvider = config.conflictProvider;
 
-    this.persistor = new CachePersistor({
-      cache: this.cache,
-      serialize: false,
-      storage: config.cacheStorage,
-      maxSize: false,
-      debug: false
-    });
+    if (config.cachePersistor) {
+      if (!(config.cachePersistor instanceof CachePersistor)) {
+        throw new Error('Error: options.cachePersistor is not a CachePersistor instance') 
+      }
+      this.persistor = config.cachePersistor
+    } else {
+      this.persistor = new CachePersistor({
+        cache: this.cache,
+        serialize: false,
+        storage: config.cacheStorage,
+        maxSize: false,
+        debug: false
+      });
+    }
 
     this.scheduler = new OffixScheduler<MutationOptions>({
       executor: this,

--- a/packages/offix-client/src/ApolloOfflineClient.ts
+++ b/packages/offix-client/src/ApolloOfflineClient.ts
@@ -51,9 +51,9 @@ export class ApolloOfflineClient extends ApolloClient<NormalizedCacheObject> {
 
     if (config.cachePersistor) {
       if (!(config.cachePersistor instanceof CachePersistor)) {
-        throw new Error('Error: options.cachePersistor is not a CachePersistor instance') 
+        throw new Error("Error: options.cachePersistor is not a CachePersistor instance");
       }
-      this.persistor = config.cachePersistor
+      this.persistor = config.cachePersistor;
     } else {
       this.persistor = new CachePersistor({
         cache: this.cache,

--- a/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
@@ -17,7 +17,6 @@ import { ApolloLink } from "apollo-link";
 import { CacheUpdates } from "offix-cache";
 import { ApolloOfflineQueueListener, createDefaultLink } from "../apollo";
 import { NormalizedCacheObject } from "apollo-cache-inmemory";
-import ApolloClient from "apollo-client";
 import { CachePersistor } from "apollo-cache-persist";
 
 /**
@@ -35,7 +34,7 @@ export class ApolloOfflineClientConfig implements ApolloOfflineClientOptions {
   public offlineStorage: PersistentStore<PersistedData>;
   public conflictListener?: ConflictListener;
   public mutationCacheUpdates?: CacheUpdates;
-  public cachePersistor?: CachePersistor<NormalizedCacheObject>;
+  public cachePersistor?: CachePersistor<object>;
   public link?: ApolloLink;
   public cache: any;
 

--- a/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
@@ -18,6 +18,7 @@ import { CacheUpdates } from "offix-cache";
 import { ApolloOfflineQueueListener, createDefaultLink } from "../apollo";
 import { NormalizedCacheObject } from "apollo-cache-inmemory";
 import ApolloClient from "apollo-client";
+import { CachePersistor } from "apollo-cache-persist";
 
 /**
  * Class for managing user and default configuration.
@@ -34,7 +35,7 @@ export class ApolloOfflineClientConfig implements ApolloOfflineClientOptions {
   public offlineStorage: PersistentStore<PersistedData>;
   public conflictListener?: ConflictListener;
   public mutationCacheUpdates?: CacheUpdates;
-  public createApolloClient?: () => ApolloClient<NormalizedCacheObject>;
+  public cachePersistor?: CachePersistor<NormalizedCacheObject>;
   public link?: ApolloLink;
   public cache: any;
 

--- a/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
@@ -33,11 +33,11 @@ export interface ApolloOfflineClientOptions extends ApolloClientOptions<Normaliz
 
   /**
    * [Modifier]
-   * 
+   *
    * The CachePersistor instance that should be used by the client.
    * Pass your own CachePersistor instance to override the default one.
    */
-  cachePersistor?: CachePersistor<NormalizedCacheObject>
+  cachePersistor?: CachePersistor<NormalizedCacheObject>;
 
   /**
    * [Modifier]

--- a/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
@@ -37,7 +37,7 @@ export interface ApolloOfflineClientOptions extends ApolloClientOptions<Normaliz
    * The CachePersistor instance that should be used by the client.
    * Pass your own CachePersistor instance to override the default one.
    */
-  cachePersistor?: CachePersistor<NormalizedCacheObject>;
+  cachePersistor?: CachePersistor<object>;
 
   /**
    * [Modifier]

--- a/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
@@ -9,10 +9,10 @@ import {
  } from "offix-conflicts-client";
 import { CacheUpdates } from "offix-cache";
 import { RetryLink } from "apollo-link-retry";
-import { ApolloLink } from "apollo-link";
 import { ApolloOfflineQueueListener } from "../apollo";
 import { NormalizedCacheObject } from "apollo-cache-inmemory";
-import ApolloClient, { ApolloClientOptions } from "apollo-client";
+import { ApolloClientOptions } from "apollo-client";
+import { CachePersistor } from "apollo-cache-persist";
 
 /**
  * Contains all configuration options required to initialize Voyager Client
@@ -30,6 +30,14 @@ export interface ApolloOfflineClientOptions extends ApolloClientOptions<Normaliz
    * Uses window.localStorage by default
    */
   cacheStorage?: PersistentStore<PersistedData>;
+
+  /**
+   * [Modifier]
+   * 
+   * The CachePersistor instance that should be used by the client.
+   * Pass your own CachePersistor instance to override the default one.
+   */
+  cachePersistor?: CachePersistor<NormalizedCacheObject>
 
   /**
    * [Modifier]

--- a/packages/offix-client/test/OfflineClient.api.test.ts
+++ b/packages/offix-client/test/OfflineClient.api.test.ts
@@ -61,12 +61,12 @@ test("registerOfflineEventListener adds the listener to the queue listeners", as
 
 test("OfflineClient accepts a persistor object", async () => {
   const link = new HttpLink({ uri: "http://test" });
-  const cache = new InMemoryCache()
+  const cache = new InMemoryCache();
 
   const cachePersistor = new CachePersistor<NormalizedCacheObject>({
     cache,
     storage: createDefaultCacheStorage()
-  })
+  });
 
   const client = new ApolloOfflineClient({
     cache,
@@ -76,21 +76,20 @@ test("OfflineClient accepts a persistor object", async () => {
 
   await client.init();
 
-  expect(client.persistor).toEqual(cachePersistor)
+  expect(client.persistor).toEqual(cachePersistor);
 });
 
 test("OfflineClient throws if cachePersistor is not a CachePersistor instance", async () => {
   const link = new HttpLink({ uri: "http://test" });
-  const cache = new InMemoryCache()
+  const cache = new InMemoryCache();
 
-  const cachePersistor = { foo: 'bar' } as unknown as CachePersistor<NormalizedCacheObject>;
+  const cachePersistor = { foo: "bar" } as unknown as CachePersistor<NormalizedCacheObject>;
 
   expect(() => {
-    new ApolloOfflineClient({
+    const client = new ApolloOfflineClient({
       cache,
       cachePersistor,
       link
     });
-  }).toThrowError('Error: options.cachePersistor is not a CachePersistor instance')
+  }).toThrowError("Error: options.cachePersistor is not a CachePersistor instance");
 });
-

--- a/packages/offix-client/test/OfflineClient.api.test.ts
+++ b/packages/offix-client/test/OfflineClient.api.test.ts
@@ -63,7 +63,7 @@ test("OfflineClient accepts a persistor object", async () => {
   const link = new HttpLink({ uri: "http://test" });
   const cache = new InMemoryCache();
 
-  const cachePersistor = new CachePersistor<NormalizedCacheObject>({
+  const cachePersistor = new CachePersistor<object>({
     cache,
     storage: createDefaultCacheStorage()
   });
@@ -83,7 +83,7 @@ test("OfflineClient throws if cachePersistor is not a CachePersistor instance", 
   const link = new HttpLink({ uri: "http://test" });
   const cache = new InMemoryCache();
 
-  const cachePersistor = { foo: "bar" } as unknown as CachePersistor<NormalizedCacheObject>;
+  const cachePersistor = { foo: "bar" } as unknown as CachePersistor<object>;
 
   expect(() => {
     const client = new ApolloOfflineClient({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

Allows the developer to pass their own `CachePersistor` object. This would close both https://github.com/aerogear/offix/issues/281 and https://github.com/aerogear/offix/issues/273

It can be done as follows:

```js
import { ApolloOfflineClient, createDefaultCacheStorage } from "offix-client";
import { HttpLink } from "apollo-link-http";
import { InMemoryCache } from "apollo-cache-inmemory";
import { CachePersistor } from "apollo-cache-persist";

const link = new HttpLink({ uri: "http://example.com/graphql" });
const cache = new InMemoryCache()

const cachePersistor = new CachePersistor({
  cache,
  storage: createDefaultCacheStorage()
})

const client = new ApolloOfflineClient({
  cache,
  cachePersistor,
  link
});
```

One thing to note, now that users can pass their own cachePersistor object. Do we need the `cacheStorage` option anymore. If you pass your own CachePersistor object then the `cacheStorage` option is no longer needed. I didn't remove it yet though because it would be a breaking change. I am happy to keep both options there but I'd like to get feedback. Any thoughts @wtrocki?


<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
