### PR TITLE
fix: error handling for when indexedDB not available

### DIFF
--- a/packages/offix-client/package.json
+++ b/packages/offix-client/package.json
@@ -47,7 +47,6 @@
     "apollo-link-http": "1.5.16",
     "apollo-link-retry": "2.2.15",
     "debug": "4.1.1",
-    "idb-localstorage": "0.2.0",
     "offix-cache": "0.13.1",
     "offix-conflicts-client": "0.13.1",
     "offix-offline": "0.13.1",

--- a/packages/offix-client/src/ApolloOfflineClient.ts
+++ b/packages/offix-client/src/ApolloOfflineClient.ts
@@ -82,8 +82,8 @@ export class ApolloOfflineClient extends ApolloClient<NormalizedCacheObject> {
       try {
         await this.persistor.restore();
       } catch(error) {
-        console.error('Error restoring Apollo cache from storage.', error);
-        console.error('Cache persistence will not be available.');
+        console.error("Error restoring Apollo cache from storage.", error);
+        console.error("Cache persistence will not be available.");
       }
     }
 

--- a/packages/offix-client/src/ApolloOfflineClient.ts
+++ b/packages/offix-client/src/ApolloOfflineClient.ts
@@ -79,7 +79,12 @@ export class ApolloOfflineClient extends ApolloClient<NormalizedCacheObject> {
 
   public async init() {
     if (this.persistor) {
-      await this.persistor.restore();
+      try {
+        await this.persistor.restore();
+      } catch(error) {
+        console.error('Error restoring Apollo cache from storage.', error);
+        console.error('Cache persistence will not be available.');
+      }
     }
 
     // Optimistic Responses

--- a/packages/offix-client/src/cache.ts
+++ b/packages/offix-client/src/cache.ts
@@ -1,5 +1,5 @@
-import { Store } from "idb-localstorage";
+import { IDBLocalStore } from "offix-scheduler";
 
 export const createDefaultCacheStorage = () => {
-  return new Store("apollo-cache", "cache-store");
+  return new IDBLocalStore("apollo-cache", "cache-store");
 };

--- a/packages/offix-scheduler/package.json
+++ b/packages/offix-scheduler/package.json
@@ -32,7 +32,6 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "idb-localstorage": "0.2.0",
     "offix-cache": "0.13.1",
     "offix-offline": "0.13.1"
   },

--- a/packages/offix-scheduler/src/OffixScheduler.ts
+++ b/packages/offix-scheduler/src/OffixScheduler.ts
@@ -55,7 +55,7 @@ export class OffixScheduler<T> {
     this.networkStatus = this.config.networkStatus;
 
     this.offlineStore = new OfflineStore(this.config.offlineStorage, this.config.serializer);
-    
+
     if (this.config.offlineQueueListener) {
       this.queueListeners.push(this.config.offlineQueueListener);
     }
@@ -75,12 +75,12 @@ export class OffixScheduler<T> {
   * Initialize the scheduler
   */
   public async init(): Promise<any> {
-    try { 
+    try {
       await this.offlineStore.init();
       await this.queue.restoreOfflineOperations();
     } catch(error) {
-      console.error('Error initializing storage for offline queue', error);
-      console.error('Offline mutations will not be persisted across restarts');
+      console.error("Error initializing storage for offline queue", error);
+      console.error("Offline mutations will not be persisted across restarts");
     }
     await this.initOnlineState();
   }

--- a/packages/offix-scheduler/src/OffixScheduler.ts
+++ b/packages/offix-scheduler/src/OffixScheduler.ts
@@ -41,7 +41,7 @@ export class OffixScheduler<T> {
   // the network status interface that determines online/offline state
   public networkStatus: NetworkStatus;
   // the offline storage interface that persists offline data across restarts
-  public offlineStore?: OfflineStore<T>;
+  public offlineStore: OfflineStore<T>;
   // the in memory queue that holds offline data
   public queue: OfflineQueue<T>;
   // listeners that can be added by the user to handle various events coming from the offline queue
@@ -54,11 +54,8 @@ export class OffixScheduler<T> {
     this.config = new OffixConfig(options);
     this.networkStatus = this.config.networkStatus;
 
-    // its possible that no storage is available
-    if (this.config.offlineStorage) {
-      this.offlineStore = new OfflineStore(this.config.offlineStorage, this.config.serializer);
-    }
-
+    this.offlineStore = new OfflineStore(this.config.offlineStorage, this.config.serializer);
+    
     if (this.config.offlineQueueListener) {
       this.queueListeners.push(this.config.offlineQueueListener);
     }
@@ -78,10 +75,14 @@ export class OffixScheduler<T> {
   * Initialize the scheduler
   */
   public async init(): Promise<any> {
-    if (this.offlineStore) {
+    try { 
       await this.offlineStore.init();
+      await this.queue.restoreOfflineOperations();
+    } catch(error) {
+      console.error('Error initializing storage for offline queue', error);
+      console.error('Offline mutations will not be persisted across restarts');
     }
-    await this.restoreOfflineOperations();
+    await this.initOnlineState();
   }
 
   /**
@@ -114,16 +115,6 @@ export class OffixScheduler<T> {
     }
   }
 
-  /**
-   * Restore offline operations into the queue
-   */
-  protected async restoreOfflineOperations() {
-
-    // reschedule offline mutations for new client instance
-    await this.queue.restoreOfflineOperations();
-    // initialize network status
-    await this.initOnlineState();
-  }
 
   protected async initOnlineState() {
     const queue = this.queue;

--- a/packages/offix-scheduler/src/index.ts
+++ b/packages/offix-scheduler/src/index.ts
@@ -5,7 +5,8 @@ export {
   OfflineStore,
   PersistentStore,
   PersistedData,
-  createDefaultOfflineStorage
+  createDefaultOfflineStorage,
+  IDBLocalStore
  } from "./store";
 
 export {

--- a/packages/offix-scheduler/src/queue/OfflineQueue.ts
+++ b/packages/offix-scheduler/src/queue/OfflineQueue.ts
@@ -55,11 +55,11 @@ export class OfflineQueue<T> {
   // listeners that can be added by the user to handle various events coming from the offline queue
   public listeners: Array<OfflineQueueListener<T>> = [];
 
-  private store?: OfflineStore<T>;
+  private store: OfflineStore<T>;
 
   private execute: QueueExecuteFunction<T>;
 
-  constructor(store: OfflineStore<T> | undefined, options: OfflineQueueConfig<T>) {
+  constructor(store: OfflineStore<T>, options: OfflineQueueConfig<T>) {
     this.store = store;
     this.execute = options.execute;
 
@@ -86,7 +86,7 @@ export class OfflineQueue<T> {
     // notify listeners
     this.onOperationEnqueued(entry.operation);
 
-    if (this.store) {
+    if (this.store.initialized) {
       try {
         await this.store.saveEntry(entry.operation);
       } catch (err) {
@@ -108,7 +108,7 @@ export class OfflineQueue<T> {
 
   public async dequeueOperation(entry: QueueEntry<T>) {
     this.queue = this.queue.filter(e => e !== entry);
-    if (this.store) {
+    if (this.store.initialized) {
       try {
         await this.store.removeEntry(entry.operation);
       } catch (err) {
@@ -141,7 +141,7 @@ export class OfflineQueue<T> {
   }
 
   public async restoreOfflineOperations() {
-    if (this.store) {
+    if (this.store.initialized) {
       try {
         const offlineEntries = await this.store.getOfflineData();
         for (const entry of offlineEntries) {

--- a/packages/offix-scheduler/src/store/IDBLocalStore.ts
+++ b/packages/offix-scheduler/src/store/IDBLocalStore.ts
@@ -1,0 +1,64 @@
+export class IDBLocalStore {
+  public readonly _dbp: Promise<IDBDatabase>;
+
+  constructor(dbName = "graphqlstore", readonly storeName = "keyval") {
+    this._dbp = new Promise((resolve, reject) => {
+      const openreq = indexedDB.open(dbName, 1);
+      openreq.onerror = () => reject(openreq.error);
+      openreq.onsuccess = () => resolve(openreq.result);
+
+      // First time setup: create an empty object store
+      openreq.onupgradeneeded = () => {
+        openreq.result.createObjectStore(storeName);
+      };
+    });
+  }
+
+  public _withIDBStore(type: IDBTransactionMode, callback: ((store: IDBObjectStore) => void)): Promise<void> {
+    return this._dbp.then(db => new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(this.storeName, type);
+      transaction.oncomplete = () => resolve();
+      transaction.onabort = transaction.onerror = () => reject(transaction.error);
+      callback(transaction.objectStore(this.storeName));
+    }));
+  }
+
+  public getItem<Type>(key: IDBValidKey): Promise<Type> {
+    let req: IDBRequest;
+    return this._withIDBStore("readonly", store => {
+      req = store.get(key);
+    }).then(() => req.result);
+  }
+
+  public setItem(key: IDBValidKey, value: any): Promise<void> {
+    return this._withIDBStore("readwrite", store => {
+      store.put(value, key);
+    });
+  }
+
+  public removeItem(key: IDBValidKey): Promise<void> {
+    return this._withIDBStore("readwrite", store => {
+      store.delete(key);
+    });
+  }
+
+  public clear(): Promise<void> {
+    return this._withIDBStore("readwrite", store => {
+      store.clear();
+    });
+  }
+
+  public keys(): Promise<IDBValidKey[]> {
+    const keys: IDBValidKey[] = [];
+
+    return this._withIDBStore("readonly", store => {
+      // This would be store.getAllKeys(), but it isn't supported by Edge or Safari.
+      // And openKeyCursor isn't supported by Safari.
+      (store.openKeyCursor || store.openCursor).call(store).onsuccess = function() {
+        if (!this.result) { return; }
+        keys.push(this.result.key);
+        this.result.continue();
+      };
+    }).then(() => keys);
+  }
+}

--- a/packages/offix-scheduler/src/store/IDBLocalStore.ts
+++ b/packages/offix-scheduler/src/store/IDBLocalStore.ts
@@ -54,6 +54,7 @@ export class IDBLocalStore {
     return this._withIDBStore("readonly", store => {
       // This would be store.getAllKeys(), but it isn't supported by Edge or Safari.
       // And openKeyCursor isn't supported by Safari.
+      // eslint-disable-next-line
       (store.openKeyCursor || store.openCursor).call(store).onsuccess = function() {
         if (!this.result) { return; }
         keys.push(this.result.key);

--- a/packages/offix-scheduler/src/store/OfflineStore.ts
+++ b/packages/offix-scheduler/src/store/OfflineStore.ts
@@ -7,12 +7,12 @@ import { OfflineStoreSerializer, DefaultOfflineSerializer } from "./OfflineStore
  */
 export class OfflineStore<T> {
 
+  public initialized: boolean = false;
   private storage: PersistentStore<PersistedData>;
   private offlineMetaKey: string = "offline-meta-data";
   private storageVersion: string = "v1";
   private arrayOfKeys: string[];
   private serializer: OfflineStoreSerializer<T>;
-  public initialized: boolean = false;
 
   constructor(storage: PersistentStore<PersistedData>, serializer?: OfflineStoreSerializer<T>) {
     this.arrayOfKeys = [];

--- a/packages/offix-scheduler/src/store/OfflineStore.ts
+++ b/packages/offix-scheduler/src/store/OfflineStore.ts
@@ -12,6 +12,7 @@ export class OfflineStore<T> {
   private storageVersion: string = "v1";
   private arrayOfKeys: string[];
   private serializer: OfflineStoreSerializer<T>;
+  public initialized: boolean = false;
 
   constructor(storage: PersistentStore<PersistedData>, serializer?: OfflineStoreSerializer<T>) {
     this.arrayOfKeys = [];
@@ -25,6 +26,7 @@ export class OfflineStore<T> {
   public async init() {
     const keys = await this.storage.getItem(this.offlineMetaKey) as string[];
     this.arrayOfKeys = keys || [];
+    this.initialized = true;
   }
 
   /**

--- a/packages/offix-scheduler/src/store/defaultStorage.ts
+++ b/packages/offix-scheduler/src/store/defaultStorage.ts
@@ -1,5 +1,5 @@
-import { Store } from "idb-localstorage";
+import { IDBLocalStore } from "./IDBLocalStore";
 
 export const createDefaultOfflineStorage = () => {
-  return new Store("offline-store", "offline-data");
+  return new IDBLocalStore("offline-store", "offline-data");
 };

--- a/packages/offix-scheduler/src/store/index.ts
+++ b/packages/offix-scheduler/src/store/index.ts
@@ -1,4 +1,5 @@
 export * from "./defaultStorage";
+export * from "./IDBLocalStore";
 export * from "./OfflineStore";
 export * from "./OfflineStoreSerializer";
 export * from "./PersistentStore";

--- a/packages/offix-scheduler/test/IDBLocalStore.test.ts
+++ b/packages/offix-scheduler/test/IDBLocalStore.test.ts
@@ -1,0 +1,79 @@
+import { IDBLocalStore } from "../src/store";
+import "fake-indexeddb/auto";
+
+let store: IDBLocalStore;
+
+describe("Empty store tests", () => {
+
+    beforeEach(() => {
+        store = new IDBLocalStore("db", "store");    
+    });
+    
+    afterEach(async () => {
+        await store.clear();    
+    });
+
+    test("Key not in local store returns is undefined", async () => {
+        const key = await store.getItem("key");
+        expect(key).toBeUndefined();
+    });
+
+    test("Key is in local store keys array when setting key value pair", async () => {
+        await store.setItem("key", "value");
+        const keys = await store.keys();
+        expect(keys).toContain("key");
+    });
+
+    test("Local store can accept multiple key value pairs", async () => {
+        await store.setItem("key1", "value1");
+        await store.setItem("key2", "value2");
+        await store.setItem("key3", "value3");
+        const keys = await store.keys();
+        expect(keys).toEqual(expect.arrayContaining(["key1", "key2", "key3"]));
+    });
+
+});
+
+describe("Populated store tests", () => {
+    
+    beforeEach(async() => {
+        store = new IDBLocalStore("db", "store");
+        await store.setItem("key", "value");
+        await store.setItem("key1", "value1");
+        await store.setItem("key2", "value2");
+        await store.setItem("key3", "value3");
+    });
+    
+    afterEach(async () => {
+        await store.clear();    
+    });
+
+    test("Local store can set and retrieve key value pair", async () => {
+        const item = await store.getItem("key");
+        expect(item).toEqual("value");
+    });
+    
+    test("Local store can remove a single key-value pair", async () => {
+        await store.removeItem("key");
+        const keys = await store.keys();
+        expect(keys).not.toContain("value");
+    });
+
+    test("Local store allows to update key value", async () => {
+        await store.setItem("key", "bar");
+        const value = await store.getItem("key");
+        expect(value).toContain("bar");
+    });
+
+    test("Clearing offline store results in empty keys array", async () => {
+        await store.clear();
+        const keys = await store.keys();
+        expect(keys).toEqual(expect.arrayContaining([]));
+    });
+
+});
+
+
+
+
+

--- a/packages/offix-scheduler/test/IDBLocalStore.test.ts
+++ b/packages/offix-scheduler/test/IDBLocalStore.test.ts
@@ -5,71 +5,71 @@ let store: IDBLocalStore;
 
 describe("Empty store tests", () => {
 
-    beforeEach(() => {
-        store = new IDBLocalStore("db", "store");
-    });
+  beforeEach(() => {
+    store = new IDBLocalStore("db", "store");
+  });
 
-    afterEach(async () => {
-        await store.clear();
-    });
+  afterEach(async () => {
+    await store.clear();
+  });
 
-    test("Key not in local store returns is undefined", async () => {
-        const key = await store.getItem("key");
-        expect(key).toBeUndefined();
-    });
+  test("Key not in local store returns is undefined", async () => {
+    const key = await store.getItem("key");
+    expect(key).toBeUndefined();
+  });
 
-    test("Key is in local store keys array when setting key value pair", async () => {
-        await store.setItem("key", "value");
-        const keys = await store.keys();
-        expect(keys).toContain("key");
-    });
+  test("Key is in local store keys array when setting key value pair", async () => {
+    await store.setItem("key", "value");
+    const keys = await store.keys();
+    expect(keys).toContain("key");
+  });
 
-    test("Local store can accept multiple key value pairs", async () => {
-        await store.setItem("key1", "value1");
-        await store.setItem("key2", "value2");
-        await store.setItem("key3", "value3");
-        const keys = await store.keys();
-        expect(keys).toEqual(expect.arrayContaining(["key1", "key2", "key3"]));
-    });
+  test("Local store can accept multiple key value pairs", async () => {
+    await store.setItem("key1", "value1");
+    await store.setItem("key2", "value2");
+    await store.setItem("key3", "value3");
+    const keys = await store.keys();
+    expect(keys).toEqual(expect.arrayContaining(["key1", "key2", "key3"]));
+  });
 
 });
 
 describe("Populated store tests", () => {
 
-    beforeEach(async () => {
-        store = new IDBLocalStore("db", "store");
-        await store.setItem("key", "value");
-        await store.setItem("key1", "value1");
-        await store.setItem("key2", "value2");
-        await store.setItem("key3", "value3");
-    });
+  beforeEach(async () => {
+    store = new IDBLocalStore("db", "store");
+    await store.setItem("key", "value");
+    await store.setItem("key1", "value1");
+    await store.setItem("key2", "value2");
+    await store.setItem("key3", "value3");
+  });
 
-    afterEach(async () => {
-        await store.clear();
-    });
+  afterEach(async () => {
+    await store.clear();
+  });
 
-    test("Local store can set and retrieve key value pair", async () => {
-        const item = await store.getItem("key");
-        expect(item).toEqual("value");
-    });
+  test("Local store can set and retrieve key value pair", async () => {
+    const item = await store.getItem("key");
+    expect(item).toEqual("value");
+  });
 
-    test("Local store can remove a single key-value pair", async () => {
-        await store.removeItem("key");
-        const keys = await store.keys();
-        expect(keys).not.toContain("value");
-    });
+  test("Local store can remove a single key-value pair", async () => {
+    await store.removeItem("key");
+    const keys = await store.keys();
+    expect(keys).not.toContain("value");
+  });
 
-    test("Local store allows to update key value", async () => {
-        await store.setItem("key", "bar");
-        const value = await store.getItem("key");
-        expect(value).toContain("bar");
-    });
+  test("Local store allows to update key value", async () => {
+    await store.setItem("key", "bar");
+    const value = await store.getItem("key");
+    expect(value).toContain("bar");
+  });
 
-    test("Clearing offline store results in empty keys array", async () => {
-        await store.clear();
-        const keys = await store.keys();
-        expect(keys).toEqual(expect.arrayContaining([]));
-    });
+  test("Clearing offline store results in empty keys array", async () => {
+    await store.clear();
+    const keys = await store.keys();
+    expect(keys).toEqual(expect.arrayContaining([]));
+  });
 
 });
 

--- a/packages/offix-scheduler/test/IDBLocalStore.test.ts
+++ b/packages/offix-scheduler/test/IDBLocalStore.test.ts
@@ -6,11 +6,11 @@ let store: IDBLocalStore;
 describe("Empty store tests", () => {
 
     beforeEach(() => {
-        store = new IDBLocalStore("db", "store");    
+        store = new IDBLocalStore("db", "store");
     });
-    
+
     afterEach(async () => {
-        await store.clear();    
+        await store.clear();
     });
 
     test("Key not in local store returns is undefined", async () => {
@@ -35,24 +35,24 @@ describe("Empty store tests", () => {
 });
 
 describe("Populated store tests", () => {
-    
-    beforeEach(async() => {
+
+    beforeEach(async () => {
         store = new IDBLocalStore("db", "store");
         await store.setItem("key", "value");
         await store.setItem("key1", "value1");
         await store.setItem("key2", "value2");
         await store.setItem("key3", "value3");
     });
-    
+
     afterEach(async () => {
-        await store.clear();    
+        await store.clear();
     });
 
     test("Local store can set and retrieve key value pair", async () => {
         const item = await store.getItem("key");
         expect(item).toEqual("value");
     });
-    
+
     test("Local store can remove a single key-value pair", async () => {
         await store.removeItem("key");
         const keys = await store.keys();
@@ -72,8 +72,5 @@ describe("Populated store tests", () => {
     });
 
 });
-
-
-
 
 

--- a/packages/offix-scheduler/test/OffixNoIDB.test.ts
+++ b/packages/offix-scheduler/test/OffixNoIDB.test.ts
@@ -2,11 +2,13 @@ import { OffixScheduler } from "../src/OffixScheduler";
 import { OffixSchedulerExecutor } from "../src/OffixSchedulerExecutor";
 import { ToggleableNetworkStatus } from "./mock/ToggleableNetworkStatus";
 
+// eslint-disable-next-line
 console.error = jest.fn();
 
 test("Offix can be initialized with no store creates console error", async () => {
   const offix = new OffixScheduler();
   await offix.init();
+  // eslint-disable-next-line
   expect(console.error).toHaveBeenCalled();
 });
 

--- a/packages/offix-scheduler/test/OffixNoIDB.test.ts
+++ b/packages/offix-scheduler/test/OffixNoIDB.test.ts
@@ -1,0 +1,44 @@
+import { OffixScheduler } from "../src/OffixScheduler";
+import { OffixSchedulerExecutor } from "../src/OffixSchedulerExecutor";
+import { ToggleableNetworkStatus } from "./mock/ToggleableNetworkStatus";
+
+console.error = jest.fn();
+
+test("Offix can be initialized with no store creates console error", async () => {
+  const offix = new OffixScheduler();
+  await offix.init();
+  expect(console.error).toHaveBeenCalled();
+});
+
+test("Offix can be initialized with no store", async () => {
+  const offix = new OffixScheduler();
+  await offix.init();
+  expect(offix.offlineStore.initialized).toBeFalsy();
+});
+
+test("Offix.execute returns an error when network status is offline and without offline storage", async () => {
+  const networkStatus = new ToggleableNetworkStatus();
+  networkStatus.setOnline(false);
+  class MockExecutor implements OffixSchedulerExecutor {
+    public async execute(options: any) {
+      const foo = options.foo;
+      return `hello ${foo}`;
+    }
+  }
+
+  const offix = new OffixScheduler({
+    executor: new MockExecutor(),
+    networkStatus
+  });
+
+  await offix.init();
+
+  try {
+    await offix.execute({ foo: "world" });
+  } catch (err) {
+    expect(err.offline).toBeTruthy();
+    networkStatus.setOnline(true);
+    const result = await err.watchOfflineChange();
+    expect(result).toBe("hello world");
+  }
+});

--- a/packages/offix-scheduler/test/OfflineStore.test.ts
+++ b/packages/offix-scheduler/test/OfflineStore.test.ts
@@ -2,10 +2,10 @@ import {
   createDefaultOfflineStorage,
   OfflineStore,
   PersistentStore,
-  PersistedData
+  PersistedData,
+  IDBLocalStore as Store
 } from "../src/store";
 import { QueueEntryOperation } from "../src/queue";
-import { Store } from "idb-localstorage";
 import "fake-indexeddb/auto";
 
 const storage = createDefaultOfflineStorage() as Store;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description
- Implemented error handling for when indexedDB not available (e.g. Firefox private mode), preventing the app from crashing
- Removed idb-localstorage dependency and added the class directly to offix-scheduler as IDBLocalStore
- Added tess for offix when indexedDB not available and added tests for IDBLocalStore

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
