### PR TITLE
chore: Remove npm update from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
       - image: circleci/node:lts-browsers
     steps:
       - checkout
-      - run:
-          name: update-npm
-          command: 'sudo npm install -g npm@latest'
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:


### PR DESCRIPTION
Motivation 

CircleCI has quota now and doing npm updates everytime is hitting the limits that npmjs put in. Recommendation from the circleci is to remove this update as it is mostly redundant and slow down the build