### PR TITLE
breaking: refactor network status interface

### DIFF
--- a/packages/offix-client-boost/integration_test/utils/network.js
+++ b/packages/offix-client-boost/integration_test/utils/network.js
@@ -26,7 +26,7 @@ export class ToggleableNetworkStatus {
   setOnline(online) {
     this.online = online;
     for (const callback of this.callbacks) {
-      callback.onStatusChange({ online })
+      callback({ online })
     }
   }
 };

--- a/packages/offix-client-boost/integration_test/utils/network.js
+++ b/packages/offix-client-boost/integration_test/utils/network.js
@@ -14,7 +14,7 @@ export class ToggleableNetworkStatus {
     this.callbacks = []
   }
 
-  onStatusChangeListener(callback) {
+  addListener(callback) {
     this.callbacks.push(callback)
   }
 

--- a/packages/offix-client/integration_test/utils/network.js
+++ b/packages/offix-client/integration_test/utils/network.js
@@ -26,7 +26,7 @@ export class ToggleableNetworkStatus {
   setOnline(online) {
     this.online = online;
     for (const callback of this.callbacks) {
-      callback.onStatusChange({ online })
+      callback({ online })
     }
   }
 };

--- a/packages/offix-client/integration_test/utils/network.js
+++ b/packages/offix-client/integration_test/utils/network.js
@@ -14,7 +14,7 @@ export class ToggleableNetworkStatus {
     this.callbacks = []
   }
 
-  onStatusChangeListener(callback) {
+  addListener(callback) {
     this.callbacks.push(callback)
   }
 

--- a/packages/offix-client/test/mock/MockNetworkStatus.ts
+++ b/packages/offix-client/test/mock/MockNetworkStatus.ts
@@ -7,8 +7,15 @@ export class MockNetworkStatus {
     this.callbacks = [];
   }
 
-  public onStatusChangeListener(callback: any) {
+  public addListener(callback: any) {
     this.callbacks.push(callback);
+  }
+
+  public removeListener(callback: any) {
+    const index = this.callbacks.indexOf(callback);
+    if (index >= 0) {
+      this.callbacks.splice(index, 1);
+    }
   }
 
   public isOffline(): Promise<boolean> {
@@ -19,7 +26,7 @@ export class MockNetworkStatus {
   public setOnline(online: boolean) {
     this.online = online;
     for (const callback of this.callbacks) {
-      callback.onStatusChange({ online });
+      callback({ online });
     }
   }
 }

--- a/packages/offix-offline/src/network/CordovaNetworkStatus.ts
+++ b/packages/offix-offline/src/network/CordovaNetworkStatus.ts
@@ -15,13 +15,13 @@ export class CordovaNetworkStatus implements NetworkStatus {
     document.addEventListener("offline", this.handleNetworkStatusChange.bind(this), false);
   }
 
-  public onStatusChangeListener(listener: NetworkStatusChangeCallback): void {
+  public addListener(listener: NetworkStatusChangeCallback): void {
     this.listeners.push(listener);
   }
 
   public removeListener(listener: NetworkStatusChangeCallback): void {
     const index = this.listeners.indexOf(listener);
-    if (index > 0) {
+    if (index >= 0) {
       this.listeners.splice(index, 1);
     }
   }
@@ -37,7 +37,7 @@ export class CordovaNetworkStatus implements NetworkStatus {
   private handleNetworkStatusChange() {
     const online = window.navigator.onLine;
     this.listeners.forEach((listener) => {
-      listener.onStatusChange({ online });
+      listener({ online });
     });
   }
 

--- a/packages/offix-offline/src/network/CordovaNetworkStatus.ts
+++ b/packages/offix-offline/src/network/CordovaNetworkStatus.ts
@@ -7,10 +7,22 @@ declare let document: any;
  * See: https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-network-information
  */
 export class CordovaNetworkStatus implements NetworkStatus {
-  public onStatusChangeListener(callback: NetworkStatusChangeCallback): void {
-    if (document) {
-      document.addEventListener("online", () => callback.onStatusChange({online: true}), false);
-      document.addEventListener("offline", () => callback.onStatusChange({online: false}), false);
+
+  listeners: NetworkStatusChangeCallback[] = [];
+
+  constructor() {
+    document.addEventListener("online", this.handleNetworkStatusChange.bind(this), false);
+    document.addEventListener("offline", this.handleNetworkStatusChange.bind(this), false);
+  }
+
+  public onStatusChangeListener(listener: NetworkStatusChangeCallback): void {
+    this.listeners.push(listener);
+  }
+
+  public removeListener(listener: NetworkStatusChangeCallback): void {
+    const index = this.listeners.indexOf(listener);
+    if (index > 0) {
+      this.listeners.splice(index, 1);
     }
   }
 
@@ -19,6 +31,13 @@ export class CordovaNetworkStatus implements NetworkStatus {
       document.addEventListener("deviceready", () => {
         resolve(!window.navigator.onLine);
       }, false);
+    });
+  }
+
+  private handleNetworkStatusChange() {
+    const online = window.navigator.onLine;
+    this.listeners.forEach((listener) => {
+      listener.onStatusChange({ online });
     });
   }
 

--- a/packages/offix-offline/src/network/NetworkStatus.ts
+++ b/packages/offix-offline/src/network/NetworkStatus.ts
@@ -2,9 +2,7 @@ export interface NetworkInfo {
   online: boolean;
 }
 
-export interface NetworkStatusChangeCallback {
-  onStatusChange(info: NetworkInfo): void;
-}
+export type NetworkStatusChangeCallback = (info: NetworkInfo) => void;
 
 /**
  * Responsable to handle Networks status
@@ -15,7 +13,7 @@ export interface NetworkStatus {
    *
    * @param callback Callback to be added when network status change
    */
-  onStatusChangeListener(listener: NetworkStatusChangeCallback): void;
+  addListener(listener: NetworkStatusChangeCallback): void;
 
   /**
    * Remove callback whenever the network status change

--- a/packages/offix-offline/src/network/NetworkStatus.ts
+++ b/packages/offix-offline/src/network/NetworkStatus.ts
@@ -11,11 +11,18 @@ export interface NetworkStatusChangeCallback {
  */
 export interface NetworkStatus {
   /**
-   * Trigger callback whenever the network status change
+   * Register callback whenever the network status change
    *
-   * @param callback Callback to be called when network status change
+   * @param callback Callback to be added when network status change
    */
-  onStatusChangeListener(callback: NetworkStatusChangeCallback): void;
+  onStatusChangeListener(listener: NetworkStatusChangeCallback): void;
+
+  /**
+   * Remove callback whenever the network status change
+   *
+   * @param callback Callback to be removed when network status change
+   */
+  removeListener(listener: NetworkStatusChangeCallback): void;
 
   /**
    * Check if device is offline

--- a/packages/offix-offline/src/network/WebNetworkStatus.ts
+++ b/packages/offix-offline/src/network/WebNetworkStatus.ts
@@ -7,16 +7,35 @@ declare let window: any;
  * See: https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/onLine
  */
 export class WebNetworkStatus implements NetworkStatus {
-  public onStatusChangeListener(callback: NetworkStatusChangeCallback): void {
-    if (window) {
-      window.addEventListener("online", () => callback.onStatusChange({online: true}), false);
-      window.addEventListener("offline", () => callback.onStatusChange({online: false}), false);
+
+  listeners: NetworkStatusChangeCallback[] = [];
+
+  constructor() {
+    window.addEventListener("online", this.handleNetworkStatusChange.bind(this), false);
+    window.addEventListener("offline", this.handleNetworkStatusChange.bind(this), false);
+  }
+
+  public onStatusChangeListener(listener: NetworkStatusChangeCallback): void {
+    this.listeners.push(listener);
+  }
+
+  public removeListener(listener: NetworkStatusChangeCallback): void {
+    const index = this.listeners.indexOf(listener);
+    if (index > 0) {
+      this.listeners.splice(index, 1);
     }
   }
 
   public isOffline(): Promise<boolean> {
     return new Promise((resolve) => {
       resolve(!window.navigator.onLine);
+    });
+  }
+
+  private handleNetworkStatusChange() {
+    const online = window.navigator.onLine;
+    this.listeners.forEach((listener) => {
+      listener.onStatusChange({ online });
     });
   }
 }

--- a/packages/offix-offline/src/network/WebNetworkStatus.ts
+++ b/packages/offix-offline/src/network/WebNetworkStatus.ts
@@ -15,13 +15,13 @@ export class WebNetworkStatus implements NetworkStatus {
     window.addEventListener("offline", this.handleNetworkStatusChange.bind(this), false);
   }
 
-  public onStatusChangeListener(listener: NetworkStatusChangeCallback): void {
+  public addListener(listener: NetworkStatusChangeCallback): void {
     this.listeners.push(listener);
   }
 
   public removeListener(listener: NetworkStatusChangeCallback): void {
     const index = this.listeners.indexOf(listener);
-    if (index > 0) {
+    if (index >= 0) {
       this.listeners.splice(index, 1);
     }
   }
@@ -35,7 +35,7 @@ export class WebNetworkStatus implements NetworkStatus {
   private handleNetworkStatusChange() {
     const online = window.navigator.onLine;
     this.listeners.forEach((listener) => {
-      listener.onStatusChange({ online });
+      listener({ online });
     });
   }
 }

--- a/packages/offix-offline/test/mock/NetworkState.ts
+++ b/packages/offix-offline/test/mock/NetworkState.ts
@@ -1,8 +1,13 @@
+import { removeListener } from "cluster";
+
 export const networkStatus = {
   isOffline() {
     return Promise.resolve(false);
   },
-  onStatusChangeListener() {
+  addListener() {
+    return;
+  },
+  removeListener() {
     return;
   }
 };

--- a/packages/offix-offline/test/mock/NetworkState.ts
+++ b/packages/offix-offline/test/mock/NetworkState.ts
@@ -1,5 +1,3 @@
-import { removeListener } from "cluster";
-
 export const networkStatus = {
   isOffline() {
     return Promise.resolve(false);

--- a/packages/offix-scheduler/src/OffixScheduler.ts
+++ b/packages/offix-scheduler/src/OffixScheduler.ts
@@ -123,13 +123,17 @@ export class OffixScheduler<T> {
     if (this.online) {
       queue.forwardOperations();
     }
-    this.networkStatus.onStatusChangeListener({
+
+    const listener = {
       onStatusChange(networkInfo: NetworkInfo) {
         self.online = networkInfo.online;
         if (self.online) {
           queue.forwardOperations();
         }
       }
-    });
+    };
+
+    this.networkStatus.onStatusChangeListener(listener);
+
   }
 }

--- a/packages/offix-scheduler/src/OffixScheduler.ts
+++ b/packages/offix-scheduler/src/OffixScheduler.ts
@@ -124,16 +124,14 @@ export class OffixScheduler<T> {
       queue.forwardOperations();
     }
 
-    const listener = {
-      onStatusChange(networkInfo: NetworkInfo) {
-        self.online = networkInfo.online;
-        if (self.online) {
-          queue.forwardOperations();
-        }
+    const listener = (networkInfo: NetworkInfo) => {
+      self.online = networkInfo.online;
+      if (self.online) {
+        queue.forwardOperations();
       }
     };
 
-    this.networkStatus.onStatusChangeListener(listener);
+    this.networkStatus.addListener(listener);
 
   }
 }

--- a/packages/offix-scheduler/test/mock/ToggleableNetworkStatus.ts
+++ b/packages/offix-scheduler/test/mock/ToggleableNetworkStatus.ts
@@ -7,8 +7,15 @@ export class ToggleableNetworkStatus {
     this.callbacks = [];
   }
 
-  public onStatusChangeListener(callback: any) {
+  public addListener(callback: any) {
     this.callbacks.push(callback);
+  }
+
+  public removeListener(callback: any) {
+    const index = this.callbacks.indexOf(callback);
+    if (index >= 0) {
+      this.callbacks.splice(index, 1);
+    }
   }
 
   public isOffline(): Promise<boolean> {
@@ -19,7 +26,7 @@ export class ToggleableNetworkStatus {
   public setOnline(online: boolean) {
     this.online = online;
     for (const callback of this.callbacks) {
-      callback.onStatusChange({ online });
+      callback({ online });
     }
   }
 }

--- a/packages/react-offix-hooks/src/useNetworkStatus.ts
+++ b/packages/react-offix-hooks/src/useNetworkStatus.ts
@@ -23,16 +23,13 @@ export function useNetworkStatus(){
 
     setOnlineStatus();
 
-    const listener: NetworkStatusChangeCallback = {
-      // get result and set online state to result
-      onStatusChange: ({ online }) => setIsOnline(online)
-    };
+    // get result and set online state to result
+    const listener: NetworkStatusChangeCallback = ({ online }) => setIsOnline(online);
 
     // set up network listener to
-    client.networkStatus.onStatusChangeListener(listener);
+    client.networkStatus.addListener(listener);
 
     return function cleanup() {
-      // @ts-ignore
       client.networkStatus.removeListener(listener);
     };
   }, [client]);

--- a/packages/react-offix-hooks/src/useNetworkStatus.ts
+++ b/packages/react-offix-hooks/src/useNetworkStatus.ts
@@ -1,5 +1,6 @@
 import  { useEffect, useState } from "react";
 import { useApolloOfflineClient } from "./ApolloOfflineProvider";
+import { NetworkStatusChangeCallback } from "offix-client";
 
 /**
  * React hook to detect network changes
@@ -13,7 +14,7 @@ export function useNetworkStatus(){
   const [isOnline, setIsOnline] = useState();
 
   useEffect(() => {
-    const setOnlineStatus  = async () => {
+    async function setOnlineStatus() {
       // check if app is offline and return result
       const offline = await client.networkStatus.isOffline();
       // set network state with result of offline check
@@ -22,12 +23,19 @@ export function useNetworkStatus(){
 
     setOnlineStatus();
 
-    // set up network listener to
-    client.networkStatus.onStatusChangeListener({
+    const listener: NetworkStatusChangeCallback = {
       // get result and set online state to result
       onStatusChange: ({ online }) => setIsOnline(online)
-    });
-  }, []);
+    };
+
+    // set up network listener to
+    client.networkStatus.onStatusChangeListener(listener);
+
+    return function cleanup() {
+      // @ts-ignore
+      client.networkStatus.removeListener(listener);
+    };
+  }, [client]);
 
   return isOnline;
 };

--- a/packages/react-offix-hooks/test/mock/MockNetworkStatus.ts
+++ b/packages/react-offix-hooks/test/mock/MockNetworkStatus.ts
@@ -7,8 +7,15 @@ export class MockNetworkStatus {
     this.callbacks = [];
   }
 
-  public onStatusChangeListener(callback: any) {
+  public addListener(callback: any) {
     this.callbacks.push(callback);
+  }
+
+  public removeListener(callback: any) {
+    const index = this.callbacks.indexOf(callback);
+    if (index >= 0) {
+      this.callbacks.splice(index, 1);
+    }
   }
 
   public isOffline(): Promise<boolean> {
@@ -19,7 +26,7 @@ export class MockNetworkStatus {
   public setOnline(online: boolean) {
     this.online = online;
     for (const callback of this.callbacks) {
-      callback.onStatusChange({ online });
+      callback({ online });
     }
   }
 }

--- a/packages/react-offix-hooks/test/useNetworkStatus.test.tsx
+++ b/packages/react-offix-hooks/test/useNetworkStatus.test.tsx
@@ -10,10 +10,10 @@ import { HttpLink } from "apollo-link-http";
 import { MockNetworkStatus } from "./mock/MockNetworkStatus";
 
 const createClient = async ({ online } : { online: boolean }) => {
-  let link = new HttpLink({ uri: "http://test" });
-  let networkStatus = new MockNetworkStatus();
+  const link = new HttpLink({ uri: "http://test" });
+  const networkStatus = new MockNetworkStatus();
   networkStatus.setOnline(online);
-  let client = new ApolloOfflineClient({
+  const client = new ApolloOfflineClient({
     cache: new InMemoryCache(),
     link,
     networkStatus


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->
## Proposed change
Currently event listeners are added to the `WebNetworkStatus` and `CordovaNetworkStatus` classes. The issue with this is that it offers no flexibility, and we keep adding listeners without the ability for removing them at a later stage. 

For now the proposed changes are only slightly breaking, as the api has been kept the same. However, instead of a new event listener being added every time, the event listeners are created on instantiated and added to the window that trigger a `handleNetworkStatusChange` method. The responsibility of this method is to loop through the array of listeners and apply the result of the status change.

Code example: 
```
const listener = {
      onStatusChange(networkInfo: NetworkInfo) {
        self.online = networkInfo.online;
        if (self.online) {
          queue.forwardOperations();
        }
      }
    };

this.networkStatus.onStatusChangeListener(listener);
```

This approach allows us to add and remove listeners more easily, which is required, for example in the cleanup of the React `useNetworkStatus` hook. eg:

```
this.networkStatus.removeListener(listener);
```

### Suggested api changes
This is open for discussion, but possibly a better api would be `addListener` instead of `onStatusChangeListener`. And instead of passing an object with a function, the function could be added directly. This would mean changing the `NetworkStatusChangeCallback` from an interface to a function type. However, these would be breaking changes.
