### PR TITLE
chore: Stop generating source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "sourceMap": true,
+    "sourceMap": false,
     "strict": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Source maps are not working and pointing to the wrong locations in ts files because of chunks for both dev and production. We need to remove them and base our debug sessions on js files which is even more easier for released packages