### PR TITLE
fix: Add mapping for conflict handling

### DIFF
--- a/packages/offix-cache/src/createOptimisticResponse.ts
+++ b/packages/offix-cache/src/createOptimisticResponse.ts
@@ -12,6 +12,7 @@ export interface OptimisticOptions {
   returnType: string;
   idField?: string;
   variables?: OperationVariables;
+  inputMapper?: (object: any) => any;
 }
 
 /**
@@ -49,9 +50,16 @@ export const createOptimisticResponse = (options: OptimisticOptions) => {
     __typename: "Mutation"
   };
 
+  let mappedVariables = variables;
+
+  if (options.inputMapper) {
+    mappedVariables = options.inputMapper(variables);
+  }
+
+
   optimisticResponse[operation] = {
     __typename: returnType,
-    ...variables,
+    ...mappedVariables,
     optimisticResponse: true
   };
   if (operationType === CacheOperation.ADD) {

--- a/packages/offix-client/src/apollo/LinksBuilder.ts
+++ b/packages/offix-client/src/apollo/LinksBuilder.ts
@@ -3,7 +3,6 @@ import { RetryLink } from "apollo-link-retry";
 import { ApolloOfflineClientConfig } from "../config/ApolloOfflineClientConfig";
 import { isMarkedOffline } from "./helpers";
 import { ConflictLink } from "./conflicts/ConflictLink";
-import { ObjectState } from "..";
 
 /**
  * Default HTTP Apollo Links
@@ -15,11 +14,7 @@ import { ObjectState } from "..";
  */
 function createDefaultLink(config: ApolloOfflineClientConfig) {
 
-  const conflictLink = new ConflictLink({
-    conflictProvider: config.conflictProvider as ObjectState,
-    conflictListener: config.conflictListener,
-    conflictStrategy: config.conflictStrategy
-  });
+  const conflictLink = new ConflictLink(config);
 
   const retryLink = ApolloLink.split(isMarkedOffline, new RetryLink(config.retryOptions));
 

--- a/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
@@ -36,7 +36,7 @@ export class ApolloOfflineClientConfig implements ApolloOfflineClientOptions {
   public cachePersistor?: CachePersistor<object>;
   public link?: ApolloLink;
   public cache: any;
-  public inputMapper: (object: any) => any | undefined;
+  public inputMapper?: (object: any) => any;
 
   public retryOptions = {
     delay: {

--- a/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
@@ -36,6 +36,7 @@ export class ApolloOfflineClientConfig implements ApolloOfflineClientOptions {
   public cachePersistor?: CachePersistor<object>;
   public link?: ApolloLink;
   public cache: any;
+  public inputMapper: (object: any) => any | undefined;
 
   public retryOptions = {
     delay: {
@@ -56,5 +57,6 @@ export class ApolloOfflineClientConfig implements ApolloOfflineClientOptions {
     this.conflictStrategy = options.conflictStrategy || UseClient;
     this.conflictProvider = options.conflictProvider || new VersionedState();
     this.link = createDefaultLink(this);
+    this.inputMapper = options.inputMapper;
   }
 }

--- a/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
@@ -1,12 +1,12 @@
 import { PersistedData, PersistentStore } from "offix-scheduler";
 import {
   NetworkStatus
- } from "offix-offline";
- import {
+} from "offix-offline";
+import {
   ConflictResolutionStrategy,
   ObjectState,
   ConflictListener
- } from "offix-conflicts-client";
+} from "offix-conflicts-client";
 import { CacheUpdates } from "offix-cache";
 import { RetryLink } from "apollo-link-retry";
 import { ApolloOfflineQueueListener } from "../apollo";
@@ -98,4 +98,12 @@ export interface ApolloOfflineClientOptions extends ApolloClientOptions<Normaliz
    *
    */
   retryOptions?: RetryLink.Options;
+
+  /**
+   * [Modifier]
+   *
+   * Maps input objects for the cases if variables are not passed to the root
+   *
+   */
+  inputMapper?: (object: any) => any;
 }


### PR DESCRIPTION
We found couple issues around the platform around mapping. 
This change introduces non breaking mapper that can be used in many places where variables are not defined on the root