### PR TITLE
fix: improve queue handling of optimistic ids + InputMapper

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,20 @@
       // "console": "integratedTerminal",
       // "internalConsoleOptions": "neverOpen",
       "port": 9229
+    },
+    {
+      "name": "Debug Jest Tests in offix-cache",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/offix-cache",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/packages/offix-cache/node_modules/.bin/jest",
+        "--runInBand"
+      ],
+      // "console": "integratedTerminal",
+      // "internalConsoleOptions": "neverOpen",
+      "port": 9229
     }
   ]
 }

--- a/docs/ref-configuration.md
+++ b/docs/ref-configuration.md
@@ -77,6 +77,52 @@ The storage can be swapped depending on the platform. For example `window.locals
 
 The options to configure how failed offline mutations are retried. See [`apollo-link-retry`](https://www.apollographql.com/docs/link/links/retry/).
 
+#### `inputMapper`
+
+If your mutation variables are not passed directly, for example if you use input types, an `inputMapper` is a set of functions that tells Offix how to read the mutation `variables`.
+
+For example, if your mutations use Input types:
+
+```js
+const CREATE_TASK = gql`
+  mutation createTask($input: TaskInput!) {
+  createTask(input: $input) {
+    id
+    title
+    description
+  }
+}`
+
+client.offlineMutate({
+  mutation: CREATE_TASK,
+  variables: {
+    input: {
+      title: 'new task title',
+      description: 'new task description'
+    }
+  },
+  returnType: 'Task'
+})
+```
+
+`ApolloOfflineClient` will need an additional `inputMapper` object with the following functions:
+
+* `deserialize` -  to know how to convert the `variables` object into a flat object that can be used to generate optimistic responses and cache update functions.
+* `serialize` - to know how to convert the serialized object back into the correct `variables` object after performing conflict resolution.
+
+```js
+import { ApolloOfflineClient, createDefaultCacheStorage } from "offix-client";
+
+const client = new ApolloOfflineClient({
+  cache: new InMemoryCache(),
+  link: new HttpLink({ uri: "http://example.com/graphql" }),
+  inputMapper: {
+    deserialize: (variables) => { return variables.input },
+    serialize: (variables) => { return { input: variables } }
+  }
+});
+```
+
 ## offix-client-boost
 
 ### `createClient`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "analyze": "source-map-explorer packages/*/dist/*.js packages/*/dist/*/*.js --onlyMapped",
-    "test": "jest",
+    "test": "jest -w 1",
     "coverage": "jest --coverage",
     "cleanInstall": "lerna exec yarn install --ignore-scripts",
     "bootstrap": "lerna bootstrap --no-ci",

--- a/packages/offix-cache/package.json
+++ b/packages/offix-cache/package.json
@@ -21,9 +21,11 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
+    "@types/traverse": "^0.6.32",
     "apollo-client": "2.6.8",
     "apollo-link": "1.2.13",
-    "apollo-utilities": "1.3.3"
+    "apollo-utilities": "1.3.3",
+    "traverse": "0.6.6"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/packages/offix-cache/package.json
+++ b/packages/offix-cache/package.json
@@ -21,11 +21,9 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "@types/traverse": "^0.6.32",
     "apollo-client": "2.6.8",
     "apollo-link": "1.2.13",
-    "apollo-utilities": "1.3.3",
-    "traverse": "0.6.6"
+    "apollo-utilities": "1.3.3"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/packages/offix-cache/src/createMutationOptions.ts
+++ b/packages/offix-cache/src/createMutationOptions.ts
@@ -5,6 +5,11 @@ import { CacheUpdatesQuery } from "./api/CacheUpdates";
 import { getOperationFieldName, deconstructQuery } from "./utils/helperFunctions";
 import { isArray } from "util";
 
+export interface InputMapper {
+  deserialize: (object: any) => any;
+  serialize: (object: any) => any;
+}
+
 /**
  * Interface to overlay helper internals on top of mutation options.
  */
@@ -34,6 +39,14 @@ export interface MutationHelperOptions<T = {
    * For example for `modifyObject(value: String!): Object` value will be `Object`
    */
   returnType?: string;
+
+  /**
+   * [Modifier]
+   *
+   * Maps input objects for the cases if variables are not passed to the root
+   *
+   */
+  inputMapper?: InputMapper;
 }
 
 /**
@@ -88,7 +101,8 @@ export const createMutationOptions = <T = {
     returnType,
     operationType = CacheOperation.ADD,
     idField = "id",
-    context
+    context,
+    inputMapper
   } = options;
 
   if (returnType && !options.optimisticResponse) {
@@ -97,7 +111,8 @@ export const createMutationOptions = <T = {
       variables,
       returnType,
       operationType,
-      idField
+      idField,
+      inputMapper
     });
   }
 

--- a/packages/offix-cache/src/createOptimisticResponse.ts
+++ b/packages/offix-cache/src/createOptimisticResponse.ts
@@ -3,6 +3,7 @@ import { CacheOperation } from "./api/CacheOperation";
 import { generateClientId } from "./utils";
 import { DocumentNode } from "graphql";
 import { OperationVariables } from "apollo-client";
+import traverse from "traverse";
 
 // export type OptimisticOptions = Omit<MutationHelperOptions, keyof MutationOptions |"updateQuery" | "context">;
 
@@ -45,13 +46,21 @@ export const createOptimisticResponse = (options: OptimisticOptions) => {
     idField = "id",
     operationType
   } = options;
+  
   const optimisticResponse: any = {
     __typename: "Mutation"
   };
 
+  const flattenedVariables = traverse(variables).reduce(function(acc, val) {
+    if (this.isLeaf && this.key) {
+      acc[this.key] = val
+    }
+    return acc
+  }, {})
+
   optimisticResponse[operation] = {
     __typename: returnType,
-    ...variables,
+    ...flattenedVariables,
     optimisticResponse: true
   };
   if (operationType === CacheOperation.ADD) {

--- a/packages/offix-cache/src/createOptimisticResponse.ts
+++ b/packages/offix-cache/src/createOptimisticResponse.ts
@@ -3,7 +3,7 @@ import { CacheOperation } from "./api/CacheOperation";
 import { generateClientId } from "./utils";
 import { DocumentNode } from "graphql";
 import { OperationVariables } from "apollo-client";
-import traverse from "traverse";
+import { InputMapper } from "./createMutationOptions";
 
 // export type OptimisticOptions = Omit<MutationHelperOptions, keyof MutationOptions |"updateQuery" | "context">;
 
@@ -13,7 +13,7 @@ export interface OptimisticOptions {
   returnType: string;
   idField?: string;
   variables?: OperationVariables;
-  inputMapper?: (object: any) => any;
+  inputMapper?: InputMapper;
 }
 
 /**
@@ -52,10 +52,10 @@ export const createOptimisticResponse = (options: OptimisticOptions) => {
     __typename: "Mutation"
   };
 
-  let mappedVariables = variables
+  let mappedVariables = variables;
 
-  if (options.inputMapper && typeof options.inputMapper === 'function') {
-    mappedVariables = options.inputMapper(variables);
+  if (options.inputMapper) {
+    mappedVariables = options.inputMapper.deserialize(variables);
   }
 
   optimisticResponse[operation] = {

--- a/packages/offix-cache/src/createOptimisticResponse.ts
+++ b/packages/offix-cache/src/createOptimisticResponse.ts
@@ -46,17 +46,17 @@ export const createOptimisticResponse = (options: OptimisticOptions) => {
     idField = "id",
     operationType
   } = options;
-  
+
   const optimisticResponse: any = {
     __typename: "Mutation"
   };
 
   const flattenedVariables = traverse(variables).reduce(function(acc, val) {
     if (this.isLeaf && this.key) {
-      acc[this.key] = val
+      acc[this.key] = val;
     }
-    return acc
-  }, {})
+    return acc;
+  }, {});
 
   optimisticResponse[operation] = {
     __typename: returnType,

--- a/packages/offix-cache/src/createOptimisticResponse.ts
+++ b/packages/offix-cache/src/createOptimisticResponse.ts
@@ -13,6 +13,7 @@ export interface OptimisticOptions {
   returnType: string;
   idField?: string;
   variables?: OperationVariables;
+  inputMapper?: (object: any) => any;
 }
 
 /**
@@ -51,16 +52,15 @@ export const createOptimisticResponse = (options: OptimisticOptions) => {
     __typename: "Mutation"
   };
 
-  const flattenedVariables = traverse(variables).reduce(function(acc, val) {
-    if (this.isLeaf && this.key) {
-      acc[this.key] = val;
-    }
-    return acc;
-  }, {});
+  let mappedVariables = variables
+
+  if (options.inputMapper && typeof options.inputMapper === 'function') {
+    mappedVariables = options.inputMapper(variables);
+  }
 
   optimisticResponse[operation] = {
     __typename: returnType,
-    ...flattenedVariables,
+    ...mappedVariables,
     optimisticResponse: true
   };
   if (operationType === CacheOperation.ADD) {

--- a/packages/offix-cache/src/utils/helperFunctions.ts
+++ b/packages/offix-cache/src/utils/helperFunctions.ts
@@ -6,8 +6,8 @@ import { CacheUpdatesQuery, QueryWithVariables } from "../api/CacheUpdates";
 import { CLIENT_ID_PREFIX } from "./constants";
 
 // Returns true if ID was generated on client
-export const isClientGeneratedId = (id: string) => {
-  return id && id.startsWith(CLIENT_ID_PREFIX);
+export const isClientGeneratedId = (id: string): boolean => {
+  return typeof id === 'string' && id.startsWith(CLIENT_ID_PREFIX);
 };
 
 // Helper method for ID generation ()

--- a/packages/offix-cache/src/utils/helperFunctions.ts
+++ b/packages/offix-cache/src/utils/helperFunctions.ts
@@ -7,7 +7,7 @@ import { CLIENT_ID_PREFIX } from "./constants";
 
 // Returns true if ID was generated on client
 export const isClientGeneratedId = (id: string): boolean => {
-  return typeof id === 'string' && id.startsWith(CLIENT_ID_PREFIX);
+  return typeof id === "string" && id.startsWith(CLIENT_ID_PREFIX);
 };
 
 // Helper method for ID generation ()

--- a/packages/offix-cache/test/OptimisticResponse.test.ts
+++ b/packages/offix-cache/test/OptimisticResponse.test.ts
@@ -41,7 +41,7 @@ test("check that createNewOptimisticResponse is without id", () => {
   expect(result.createItem.id).toBe(undefined);
 });
 
-test("createOptimisticResponse flattens the variables object into top level keys", () => {
+test("createOptimisticResponse works with an input mapper", () => {
   const options: OptimisticOptions = {
     mutation: CREATE_ITEM,
     operationType: CacheOperation.REFRESH,
@@ -53,13 +53,12 @@ test("createOptimisticResponse flattens the variables object into top level keys
         id: "123",
         name: "test"
       }
-    }
+    },
+    inputMapper: (vars) => vars.input
   };
   const result = createOptimisticResponse(options);
   expect(result.createItem).toStrictEqual({
     __typename: "Test",
-    a: "val1",
-    b: "val2",
     id: "123",
     name: "test",
     optimisticResponse: true

--- a/packages/offix-cache/test/OptimisticResponse.test.ts
+++ b/packages/offix-cache/test/OptimisticResponse.test.ts
@@ -47,21 +47,21 @@ test("createOptimisticResponse flattens the variables object into top level keys
     operationType: CacheOperation.REFRESH,
     returnType: "Test",
     variables: {
-      a: 'val1',
-      b: 'val2',
+      a: "val1",
+      b: "val2",
       input: {
-        id: '123',
-        name: 'test'
+        id: "123",
+        name: "test"
       }
     }
   };
   const result = createOptimisticResponse(options);
   expect(result.createItem).toStrictEqual({
     __typename: "Test",
-    a: 'val1',
-    b: 'val2',
-    id: '123',
-    name: 'test',
+    a: "val1",
+    b: "val2",
+    id: "123",
+    name: "test",
     optimisticResponse: true
   });
 });

--- a/packages/offix-cache/test/OptimisticResponse.test.ts
+++ b/packages/offix-cache/test/OptimisticResponse.test.ts
@@ -40,3 +40,28 @@ test("check that createNewOptimisticResponse is without id", () => {
   const result = createOptimisticResponse(options);
   expect(result.createItem.id).toBe(undefined);
 });
+
+test("createOptimisticResponse flattens the variables object into top level keys", () => {
+  const options: OptimisticOptions = {
+    mutation: CREATE_ITEM,
+    operationType: CacheOperation.REFRESH,
+    returnType: "Test",
+    variables: {
+      a: 'val1',
+      b: 'val2',
+      input: {
+        id: '123',
+        name: 'test'
+      }
+    }
+  };
+  const result = createOptimisticResponse(options);
+  expect(result.createItem).toStrictEqual({
+    __typename: "Test",
+    a: 'val1',
+    b: 'val2',
+    id: '123',
+    name: 'test',
+    optimisticResponse: true
+  });
+});

--- a/packages/offix-cache/test/OptimisticResponse.test.ts
+++ b/packages/offix-cache/test/OptimisticResponse.test.ts
@@ -54,7 +54,10 @@ test("createOptimisticResponse works with an input mapper", () => {
         name: "test"
       }
     },
-    inputMapper: (vars) => vars.input
+    inputMapper: {
+      deserialize: (vars) => vars.input,
+      serialize: (vars) => vars
+    }
   };
   const result = createOptimisticResponse(options);
   expect(result.createItem).toStrictEqual({

--- a/packages/offix-client/integration_test/karma.conf.js
+++ b/packages/offix-client/integration_test/karma.conf.js
@@ -66,7 +66,7 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true,
+    singleRun: process.env.DEBUG ? false : true,
 
     // Concurrency level
     // how many browser should be started simultaneous

--- a/packages/offix-client/package.json
+++ b/packages/offix-client/package.json
@@ -38,7 +38,7 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "@types/traverse": "^0.6.32",
+    "@types/traverse": "0.6.32",
     "apollo-cache-inmemory": "1.6.5",
     "apollo-cache-persist": "0.1.1",
     "apollo-client": "2.6.8",

--- a/packages/offix-client/package.json
+++ b/packages/offix-client/package.json
@@ -50,7 +50,7 @@
     "offix-conflicts-client": "0.13.2",
     "offix-offline": "0.13.2",
     "offix-scheduler": "0.13.2",
-    "traverse": "^0.6.6"
+    "traverse": "0.6.6"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/packages/offix-client/package.json
+++ b/packages/offix-client/package.json
@@ -38,6 +38,7 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
+    "@types/traverse": "^0.6.32",
     "apollo-cache-inmemory": "1.6.5",
     "apollo-cache-persist": "0.1.1",
     "apollo-client": "2.6.8",

--- a/packages/offix-client/package.json
+++ b/packages/offix-client/package.json
@@ -48,7 +48,8 @@
     "offix-cache": "0.13.2",
     "offix-conflicts-client": "0.13.2",
     "offix-offline": "0.13.2",
-    "offix-scheduler": "0.13.2"
+    "offix-scheduler": "0.13.2",
+    "traverse": "^0.6.6"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/packages/offix-client/src/ApolloOfflineClient.ts
+++ b/packages/offix-client/src/ApolloOfflineClient.ts
@@ -93,7 +93,7 @@ export class ApolloOfflineClient extends ApolloClient<NormalizedCacheObject> {
         addOptimisticResponse(this, operation);
       },
       onOperationSuccess: (operation: ApolloQueueEntryOperation, result: FetchResult) => {
-        replaceClientGeneratedIDsInQueue(this.scheduler.queue, operation, result);
+        replaceClientGeneratedIDsInQueue(this.scheduler.queue.queue, operation, result);
         removeOptimisticResponse(this, operation);
       },
       onOperationFailure: (operation: ApolloQueueEntryOperation, error) => {

--- a/packages/offix-client/src/ApolloOfflineClient.ts
+++ b/packages/offix-client/src/ApolloOfflineClient.ts
@@ -93,7 +93,7 @@ export class ApolloOfflineClient extends ApolloClient<NormalizedCacheObject> {
         addOptimisticResponse(this, operation);
       },
       onOperationSuccess: (operation: ApolloQueueEntryOperation, result: FetchResult) => {
-        replaceClientGeneratedIDsInQueue(this.scheduler.queue.queue, operation, result);
+        replaceClientGeneratedIDsInQueue(this.scheduler.queue, operation, result);
         removeOptimisticResponse(this, operation);
       },
       onOperationFailure: (operation: ApolloQueueEntryOperation, error) => {

--- a/packages/offix-client/src/apollo/LinksBuilder.ts
+++ b/packages/offix-client/src/apollo/LinksBuilder.ts
@@ -18,7 +18,8 @@ function createDefaultLink(config: ApolloOfflineClientConfig) {
   const conflictLink = new ConflictLink({
     conflictProvider: config.conflictProvider as ObjectState,
     conflictListener: config.conflictListener,
-    conflictStrategy: config.conflictStrategy
+    conflictStrategy: config.conflictStrategy,
+    inputMapper: config.inputMapper
   });
 
   const retryLink = ApolloLink.split(isMarkedOffline, new RetryLink(config.retryOptions));

--- a/packages/offix-client/src/apollo/conflicts/baseHelpers.ts
+++ b/packages/offix-client/src/apollo/conflicts/baseHelpers.ts
@@ -1,4 +1,4 @@
-import { MutationOptions } from "apollo-client";
+import { MutationOptions, OperationVariables } from "apollo-client";
 import { ApolloCache } from "apollo-cache";
 import {
   ObjectState,
@@ -6,6 +6,7 @@ import {
   ConflictResolutionData
 } from "offix-conflicts-client";
 import { NormalizedCacheObject } from "apollo-cache-inmemory";
+import { flattenObject } from "../../utils/objectUtils";
 
 /**
  * Convenience interface that specifies a few extra properties found on ApolloCache
@@ -36,10 +37,12 @@ export function getBaseStateFromCache(
   const context = mutationOptions.context;
 
   if (!context.conflictBase) {
-    // do nothing
-    const conflictBase = getObjectFromCache(cache, context.returnType, mutationOptions);
+    // flatten the mutation variables first to handle input types
+    const flattenedVariables = flattenObject(mutationOptions.variables);
+
+    const conflictBase = getObjectFromCache(cache, context.returnType, flattenedVariables);
     if (conflictBase && Object.keys(conflictBase).length !== 0) {
-      if (objectState.hasConflict(mutationOptions.variables, conflictBase)) {
+      if (objectState.hasConflict(flattenedVariables, conflictBase)) {
         // 🙊 Input data is conflicted with the latest server projection
         throw new LocalConflictError(conflictBase, mutationOptions.variables);
       }
@@ -48,9 +51,9 @@ export function getBaseStateFromCache(
   }
 }
 
-function getObjectFromCache(cache: ApolloCacheWithData, typename: string, mutationOptions: MutationOptions) {
+function getObjectFromCache(cache: ApolloCacheWithData, typename: string, mutationVariables: OperationVariables) {
   if (cache && cache.data) {
-    const idKey = cache.config.dataIdFromObject({ __typename: typename, ...mutationOptions.variables });
+    const idKey = cache.config.dataIdFromObject({ __typename: typename, ...mutationVariables });
 
     if (cache.optimisticData && cache.optimisticData.parent) {
       const optimisticData = cache.optimisticData.parent.data;

--- a/packages/offix-client/src/apollo/conflicts/baseHelpers.ts
+++ b/packages/offix-client/src/apollo/conflicts/baseHelpers.ts
@@ -6,6 +6,7 @@ import {
   ConflictResolutionData
 } from "offix-conflicts-client";
 import { NormalizedCacheObject } from "apollo-cache-inmemory";
+import { InputMapper } from "../../config/ApolloOfflineClientOptions";
 
 /**
  * Convenience interface that specifies a few extra properties found on ApolloCache
@@ -32,15 +33,15 @@ export function getBaseStateFromCache(
   cache: ApolloCacheWithData,
   objectState: ObjectState,
   mutationOptions: MutationOptions,
-  inputMapper?: (object: any) => any
+  inputMapper?: InputMapper
 ): ConflictResolutionData {
   const context = mutationOptions.context;
 
   if (!context.conflictBase) {
 
-    let mutationVariables = mutationOptions.variables as OperationVariables
+    let mutationVariables = mutationOptions.variables as OperationVariables;
     if (inputMapper) {
-      mutationVariables = inputMapper(mutationVariables)
+      mutationVariables = inputMapper.deserialize(mutationVariables);
     }
 
     const conflictBase = getObjectFromCache(cache, context.returnType, mutationVariables);

--- a/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
+++ b/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
@@ -3,7 +3,7 @@ import { CacheUpdates, isClientGeneratedId } from "offix-cache";
 import { FetchResult } from "apollo-link";
 import ApolloClient from "apollo-client";
 import { NormalizedCacheObject } from "apollo-cache-inmemory";
-import traverse from "traverse";
+import { deepUpdateValueInObject } from '../utils/objectUtils'
 
 export function addOptimisticResponse(apolloClient: ApolloClient<NormalizedCacheObject>, { op, qid }: ApolloQueueEntryOperation) {
   apolloClient.store.markMutationInit({
@@ -65,11 +65,7 @@ export function replaceClientGeneratedIDsInQueue(queue: ApolloQueueEntry[], oper
     queue.forEach((entry) => {
       // replace all instances of the optimistic id in the queue with
       // the new id that came back from the server
-      traverse(entry.operation.op.variables).forEach(function(val) {
-        if (this.isLeaf && val && val.toString() === optimisticId.toString()) {
-          this.update(resultId);
-        }
-      });
+      deepUpdateValueInObject(entry.operation.op.variables, optimisticId, resultId)
     });
   }
 }

--- a/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
+++ b/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
@@ -1,4 +1,4 @@
-import { ApolloQueueEntryOperation, ApolloOfflineQueue } from "./ApolloOfflineTypes";
+import { ApolloQueueEntryOperation, ApolloQueueEntry } from "./ApolloOfflineTypes";
 import { CacheUpdates, isClientGeneratedId } from "offix-cache";
 import { FetchResult } from "apollo-link";
 import ApolloClient from "apollo-client";

--- a/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
+++ b/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
@@ -44,18 +44,18 @@ export function restoreOptimisticResponse(
  * with the actual ID returned from the server.
  */
 export function replaceClientGeneratedIDsInQueue(queue: ApolloOfflineQueue, operation: ApolloQueueEntryOperation, result: FetchResult) {
-  
+
   const op = operation.op;
   const operationName = op.context.operationName as string;
   const optimisticResponse = op.optimisticResponse as {[key: string]: any};
-  
+
   if (!optimisticResponse) {
     return;
   }
 
   const idField = op.context.idField || "id";
   const optimisticId = optimisticResponse[operationName] && optimisticResponse[operationName][idField];
-  const resultId = result && result.data && result.data[operationName] && result.data[operationName][idField]
+  const resultId = result && result.data && result.data[operationName] && result.data[operationName][idField];
 
   if (!optimisticId || !resultId) {
     return;
@@ -67,9 +67,9 @@ export function replaceClientGeneratedIDsInQueue(queue: ApolloOfflineQueue, oper
       // the new id that came back from the server
       traverse(entry.operation.op.variables).forEach(function(val) {
         if (this.isLeaf && val && val.toString() === optimisticId.toString()) {
-          this.update(resultId)
+          this.update(resultId);
         }
-      })
+      });
     });
   }
 }

--- a/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
+++ b/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
@@ -3,7 +3,7 @@ import { CacheUpdates, isClientGeneratedId } from "offix-cache";
 import { FetchResult } from "apollo-link";
 import ApolloClient from "apollo-client";
 import { NormalizedCacheObject } from "apollo-cache-inmemory";
-import { deepUpdateValueInObject } from "../utils/objectUtils";
+import traverse from "traverse";
 
 export function addOptimisticResponse(apolloClient: ApolloClient<NormalizedCacheObject>, { op, qid }: ApolloQueueEntryOperation) {
   apolloClient.store.markMutationInit({
@@ -65,7 +65,11 @@ export function replaceClientGeneratedIDsInQueue(queue: ApolloQueueEntry[], oper
     queue.forEach((entry) => {
       // replace all instances of the optimistic id in the queue with
       // the new id that came back from the server
-      deepUpdateValueInObject(entry.operation.op.variables, optimisticId, resultId);
+      traverse(entry.operation.op.variables).forEach(function(val) {
+        if (this.isLeaf && val && val === optimisticId) {
+          this.update(resultId);
+        }
+      });
     });
   }
 }

--- a/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
+++ b/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
@@ -3,7 +3,7 @@ import { CacheUpdates, isClientGeneratedId } from "offix-cache";
 import { FetchResult } from "apollo-link";
 import ApolloClient from "apollo-client";
 import { NormalizedCacheObject } from "apollo-cache-inmemory";
-import { deepUpdateValueInObject } from '../utils/objectUtils'
+import { deepUpdateValueInObject } from "../utils/objectUtils";
 
 export function addOptimisticResponse(apolloClient: ApolloClient<NormalizedCacheObject>, { op, qid }: ApolloQueueEntryOperation) {
   apolloClient.store.markMutationInit({
@@ -65,7 +65,7 @@ export function replaceClientGeneratedIDsInQueue(queue: ApolloQueueEntry[], oper
     queue.forEach((entry) => {
       // replace all instances of the optimistic id in the queue with
       // the new id that came back from the server
-      deepUpdateValueInObject(entry.operation.op.variables, optimisticId, resultId)
+      deepUpdateValueInObject(entry.operation.op.variables, optimisticId, resultId);
     });
   }
 }

--- a/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
+++ b/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
@@ -43,7 +43,7 @@ export function restoreOptimisticResponse(
  * we need to update all references in the queue to the client generated ID
  * with the actual ID returned from the server.
  */
-export function replaceClientGeneratedIDsInQueue(queue: ApolloOfflineQueue, operation: ApolloQueueEntryOperation, result: FetchResult) {
+export function replaceClientGeneratedIDsInQueue(queue: ApolloQueueEntry[], operation: ApolloQueueEntryOperation, result: FetchResult) {
 
   const op = operation.op;
   const operationName = op.context.operationName as string;
@@ -62,7 +62,7 @@ export function replaceClientGeneratedIDsInQueue(queue: ApolloOfflineQueue, oper
   }
 
   if (isClientGeneratedId(optimisticId)) {
-    queue.queue.forEach((entry) => {
+    queue.forEach((entry) => {
       // replace all instances of the optimistic id in the queue with
       // the new id that came back from the server
       traverse(entry.operation.op.variables).forEach(function(val) {

--- a/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
@@ -3,7 +3,7 @@ import {
   PersistentStore,
   createDefaultOfflineStorage
 } from "offix-scheduler";
-import { ApolloOfflineClientOptions } from "./ApolloOfflineClientOptions";
+import { ApolloOfflineClientOptions, InputMapper } from "./ApolloOfflineClientOptions";
 import { NetworkStatus } from "offix-offline";
 import {
   ConflictResolutionStrategy,
@@ -35,7 +35,7 @@ export class ApolloOfflineClientConfig implements ApolloOfflineClientOptions {
   public mutationCacheUpdates?: CacheUpdates;
   public cachePersistor?: CachePersistor<object>;
   public link?: ApolloLink;
-  public inputMapper?: (object: any) => any;
+  public inputMapper?: InputMapper;
   public cache: any;
 
   public retryOptions = {

--- a/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
@@ -35,6 +35,7 @@ export class ApolloOfflineClientConfig implements ApolloOfflineClientOptions {
   public mutationCacheUpdates?: CacheUpdates;
   public cachePersistor?: CachePersistor<object>;
   public link?: ApolloLink;
+  public inputMapper?: (object: any) => any;
   public cache: any;
 
   public retryOptions = {

--- a/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
@@ -14,6 +14,11 @@ import { NormalizedCacheObject } from "apollo-cache-inmemory";
 import { ApolloClientOptions } from "apollo-client";
 import { CachePersistor } from "apollo-cache-persist";
 
+export interface InputMapper {
+  deserialize: (object: any) => any;
+  serialize: (object: any) => any;
+}
+
 /**
  * Contains all configuration options required to initialize Voyager Client
  * Options marked with [Modifier] flag are used to modify behavior of client.
@@ -105,5 +110,5 @@ export interface ApolloOfflineClientOptions extends ApolloClientOptions<Normaliz
    * Maps input objects for the cases if variables are not passed to the root
    *
    */
-  inputMapper?: (object: any) => any;
+  inputMapper?: InputMapper;
 }

--- a/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientOptions.ts
@@ -98,4 +98,12 @@ export interface ApolloOfflineClientOptions extends ApolloClientOptions<Normaliz
    *
    */
   retryOptions?: RetryLink.Options;
+
+  /**
+   * [Modifier]
+   *
+   * Maps input objects for the cases if variables are not passed to the root
+   *
+   */
+  inputMapper?: (object: any) => any;
 }

--- a/packages/offix-client/src/index.ts
+++ b/packages/offix-client/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./config/ApolloOfflineClientOptions";
+export { ApolloOfflineClientOptions, InputMapper } from "./config/ApolloOfflineClientOptions";
 export * from "./ApolloOfflineClient";
 export * from "./apollo/ApolloOfflineTypes";
 export * from "./apollo/conflicts/ConflictLink";

--- a/packages/offix-client/src/utils/objectUtils.ts
+++ b/packages/offix-client/src/utils/objectUtils.ts
@@ -1,0 +1,40 @@
+import traverse from "traverse";
+
+// given an object with nested objects
+// example: { a: 1, b: { c: 2, d: 3 } }
+// flatten the object into top level keys
+// { a: 1, c: 2, d: 3 }
+// will behave unexpectedly if multiple nested objects
+// use the same key value
+export function flattenObject(obj: any): object {
+  return traverse(obj).reduce(function(acc, val) {
+    if (this.isLeaf && this.key) {
+      acc[this.key] = val;
+    }
+    return acc;
+  }, {});
+}
+
+// given an object with a structure we don't know,
+// replace all instances of the targetValue with the newValue
+export function deepUpdateValueInObject(obj: any, targetValue: any, newValue: any): void {
+  traverse(obj).forEach(function(val) {
+    if (this.isLeaf && val && val === targetValue) {
+      this.update(newValue);
+    }
+  });
+}
+
+// Given a src object that may or may not contain nested objects.
+// example: { input: { id: 123, a: 1, b: 2 } }
+// and given a flat targetObject - example: { id: 123, a: 2, b: 3 }
+// match the target object to the nested object by id and
+// return a new object where the nested object is replaced with the target object
+// result: { input: { id: 123, a: 2, b: 3 } }
+export function replaceNestedObjectById(srcObject: any, targetObject: any, idField: any) {
+  return traverse(srcObject).map(function(val) {
+    if (val && this.notLeaf && val[idField] && val[idField] === targetObject[idField]) {
+      this.update(targetObject, true);
+    }
+  });
+}

--- a/packages/offix-client/src/utils/objectUtils.ts
+++ b/packages/offix-client/src/utils/objectUtils.ts
@@ -33,7 +33,7 @@ export function deepUpdateValueInObject(obj: any, targetValue: any, newValue: an
 // result: { input: { id: 123, a: 2, b: 3 } }
 export function replaceNestedObjectById(srcObject: any, targetObject: any, idField: any) {
   return traverse(srcObject).map(function(val) {
-    if (val && this.notLeaf && val[idField] && val[idField] === targetObject[idField]) {
+    if (val && this.notLeaf && val[idField] && val[idField].toString() === targetObject[idField].toString()) {
       this.update(targetObject, true);
     }
   });

--- a/packages/offix-client/src/utils/objectUtils.ts
+++ b/packages/offix-client/src/utils/objectUtils.ts
@@ -1,40 +1,11 @@
 import traverse from "traverse";
 
-// given an object with nested objects
-// example: { a: 1, b: { c: 2, d: 3 } }
-// flatten the object into top level keys
-// { a: 1, c: 2, d: 3 }
-// will behave unexpectedly if multiple nested objects
-// use the same key value
-export function flattenObject(obj: any): object {
-  return traverse(obj).reduce(function(acc, val) {
-    if (this.isLeaf && this.key) {
-      acc[this.key] = val;
-    }
-    return acc;
-  }, {});
-}
-
 // given an object with a structure we don't know,
 // replace all instances of the targetValue with the newValue
 export function deepUpdateValueInObject(obj: any, targetValue: any, newValue: any): void {
   traverse(obj).forEach(function(val) {
     if (this.isLeaf && val && val === targetValue) {
       this.update(newValue);
-    }
-  });
-}
-
-// Given a src object that may or may not contain nested objects.
-// example: { input: { id: 123, a: 1, b: 2 } }
-// and given a flat targetObject - example: { id: 123, a: 2, b: 3 }
-// match the target object to the nested object by id and
-// return a new object where the nested object is replaced with the target object
-// result: { input: { id: 123, a: 2, b: 3 } }
-export function replaceNestedObjectById(srcObject: any, targetObject: any, idField: any) {
-  return traverse(srcObject).map(function(val) {
-    if (val && this.notLeaf && val[idField] && val[idField].toString() === targetObject[idField].toString()) {
-      this.update(targetObject, true);
     }
   });
 }

--- a/packages/offix-client/test/optimisticResponseHelpers.test.ts
+++ b/packages/offix-client/test/optimisticResponseHelpers.test.ts
@@ -48,7 +48,7 @@ test("Process with change", () => {
 });
 
 test("Can handle cases where variables is a nested object", () => {
-  const optimisticId = "client:1"
+  const optimisticId = "client:1";
   const op0 = {
     operation: {
       qid: "queue:1",
@@ -65,7 +65,7 @@ test("Can handle cases where variables is a nested object", () => {
         }
       }
     }
-  }
+  };
   const op1 = {
     operation: {
       qid: "queue:2",
@@ -82,10 +82,10 @@ test("Can handle cases where variables is a nested object", () => {
         }
       }
     }
-  }
-  const queue = [op0, op1]
+  };
+  const queue = [op0, op1];
 
-  const op0Result = { data: { someOperation: { id: "applied:1" } } }
+  const op0Result = { data: { someOperation: { id: "applied:1" } } };
   replaceClientGeneratedIDsInQueue(queue, op0.operation, op0Result);
   expect(op0.operation.op.variables.someOperationInput.id).toBe("applied:1");
   expect(op1.operation.op.variables.anotherOperationInput.id).toBe("applied:1");
@@ -108,7 +108,7 @@ test("Can handle cases optimistic value is referenced in other keys (example: re
         }
       }
     }
-  }
+  };
   const op1 = {
     operation: {
       qid: "queue:2",
@@ -126,10 +126,10 @@ test("Can handle cases optimistic value is referenced in other keys (example: re
         }
       }
     }
-  }
-  const queue = [op0, op1]
+  };
+  const queue = [op0, op1];
 
-  const op0Result = { data: { createExample: { id: "applied:1" } } }
+  const op0Result = { data: { createExample: { id: "applied:1" } } };
   replaceClientGeneratedIDsInQueue(queue, op0.operation, op0Result);
   expect(op1.operation.op.variables.anotherCreateExampleInput.parentId).toBe("applied:1");
 });

--- a/packages/offix-client/test/optimisticResponseHelpers.test.ts
+++ b/packages/offix-client/test/optimisticResponseHelpers.test.ts
@@ -2,47 +2,134 @@ import { replaceClientGeneratedIDsInQueue } from "../src/apollo/optimisticRespon
 import { DocumentNode } from "graphql";
 
 test("Process id without change", () => {
-    const finalId = "test:1";
-    const exampleOperation = {
-        mutation: {} as DocumentNode,
-        variables: {
-            id: finalId
-        },
-        optimisticResponse: { test: { id: finalId } },
-        context: {
-            operationName: "test"
-        }
-    };
-    const entry = {
-        operation: {
-            op: exampleOperation,
-            qid: "someId"
-        }
-    };
-    const queue = [entry];
-    replaceClientGeneratedIDsInQueue(queue, entry.operation, { data: { test: { id: "notApplied:1" } } });
-    expect(exampleOperation.variables.id).toBe(finalId);
+  const finalId = "test:1";
+  const exampleOperation = {
+    mutation: {} as DocumentNode,
+    variables: {
+      id: finalId
+    },
+    optimisticResponse: { test: { id: finalId } },
+    context: {
+      operationName: "test"
+    }
+  };
+  const entry = {
+    operation: {
+      op: exampleOperation,
+      qid: "someId"
+    }
+  };
+  const queue = [entry];
+  replaceClientGeneratedIDsInQueue(queue, entry.operation, { data: { test: { id: "notApplied:1" } } });
+  expect(exampleOperation.variables.id).toBe(finalId);
 });
 
 test("Process with change", () => {
-    const finalId = "client:";
-    const exampleOperation = {
+  const finalId = "client:1";
+  const exampleOperation = {
+    mutation: {} as DocumentNode,
+    variables: {
+      id: finalId
+    },
+    optimisticResponse: { test: { id: finalId } },
+    context: {
+      operationName: "test"
+    }
+  };
+  const entry = {
+    operation: {
+      op: exampleOperation,
+      qid: "someId"
+    }
+  };
+  const queue = [entry];
+  replaceClientGeneratedIDsInQueue(queue, entry.operation, { data: { test: { id: "applied:1" } } });
+  expect(exampleOperation.variables.id).toBe("applied:1");
+});
+
+test("Can handle cases where variables is a nested object", () => {
+  const optimisticId = "client:1"
+  const op0 = {
+    operation: {
+      qid: "queue:1",
+      op: {
         mutation: {} as DocumentNode,
         variables: {
-            id: finalId
+          someOperationInput: {
+            id: optimisticId
+          }
         },
-        optimisticResponse: { test: { id: finalId } },
+        optimisticResponse: { someOperation: { id: optimisticId } },
         context: {
-            operationName: "test"
+          operationName: "someOperation"
         }
-    };
-    const entry = {
-        operation: {
-            op: exampleOperation,
-            qid: "someId"
+      }
+    }
+  }
+  const op1 = {
+    operation: {
+      qid: "queue:2",
+      op: {
+        mutation: {} as DocumentNode,
+        variables: {
+          anotherOperationInput: {
+            id: optimisticId
+          }
+        },
+        optimisticResponse: { anotherOperation: { id: optimisticId } },
+        context: {
+          operationName: "anotherOperation"
         }
-    };
-    const queue = [entry];
-    replaceClientGeneratedIDsInQueue(queue, entry.operation, { data: { test: { id: "applied:1" } } });
-    expect(exampleOperation.variables.id).toBe("applied:1");
+      }
+    }
+  }
+  const queue = [op0, op1]
+
+  const op0Result = { data: { someOperation: { id: "applied:1" } } }
+  replaceClientGeneratedIDsInQueue(queue, op0.operation, op0Result);
+  expect(op0.operation.op.variables.someOperationInput.id).toBe("applied:1");
+  expect(op1.operation.op.variables.anotherOperationInput.id).toBe("applied:1");
+});
+
+test("Can handle cases optimistic value is referenced in other keys (example: relationships)", () => {
+  const op0 = {
+    operation: {
+      qid: "queue:1",
+      op: {
+        mutation: {} as DocumentNode,
+        variables: {
+          createExample: {
+            id: "client:1"
+          }
+        },
+        optimisticResponse: { createExample: { id: "client:1" } },
+        context: {
+          operationName: "createExample"
+        }
+      }
+    }
+  }
+  const op1 = {
+    operation: {
+      qid: "queue:2",
+      op: {
+        mutation: {} as DocumentNode,
+        variables: {
+          anotherCreateExampleInput: {
+            id: "client:2",
+            parentId: "client:1" // references the first operation
+          }
+        },
+        optimisticResponse: { anotherCreateExample: { id: "client:2" } },
+        context: {
+          operationName: "anotherCreateExample"
+        }
+      }
+    }
+  }
+  const queue = [op0, op1]
+
+  const op0Result = { data: { createExample: { id: "applied:1" } } }
+  replaceClientGeneratedIDsInQueue(queue, op0.operation, op0Result);
+  expect(op1.operation.op.variables.anotherCreateExampleInput.parentId).toBe("applied:1");
 });

--- a/packages/offix-client/traversetest.js
+++ b/packages/offix-client/traversetest.js
@@ -1,0 +1,33 @@
+const traverse = require('traverse')
+
+const variables = {
+  input: {
+    "id": "5e5fa07295ea8401bfefb1f7",
+    "title": "updated for conflict agaon",
+    "description": "wqqw",
+    "status": null,
+    "version": 13
+  }
+}
+
+const resolved = {
+  "id": "5e5fa07295ea8401bfefb1f7",
+  "title": "updated for conflict",
+  "description": "wqqw",
+  "version": 14
+}
+
+function replaceNestedObjectByIdValue(srcObject, targetObject, idField) {
+  return traverse(srcObject).map(function(val) {
+    if (val && this.notLeaf && val[idField] && val[idField] === targetObject[idField]) {
+      console.log('updating')
+      this.update(targetObject, true)
+    }
+  })
+}
+
+console.log(variables)
+
+const result = replaceNestedObjectByIdValue(variables, resolved, 'id')
+
+console.log(result)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

I've brought in a new dependency in order to solve these issues. [traverse](https://github.com/substack/js-traverse/blob/master/index.js) is a ~300 line dependency.

* `createOptimisticResponse` flattens `variables` this means no need for a mapper function. If this flattening does not work, then use `createOptimisticResponse` directly passing in the correct variables, or supply your own object.

* `replaceClientGeneratedIdsInQueue` is able to deep replace optimistic id values in queue entries no matter the location. This solves issues where `variables` isn't a flat object. (e.g. using `input` types). It also solves issues where entries in the queue reference other optimistically created objects. i.e. https://github.com/aerogear/offix/issues/367



Check unit tests for examples

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
