### PR TITLE
feat: allow for adding conflict listeners after client creation

### DIFF
--- a/docs/ref-conflict-client.md
+++ b/docs/ref-conflict-client.md
@@ -143,9 +143,7 @@ class ConflictLogger implements ConflictListener {
   }
 }
 
-let config = {
-...
-  conflictListener: new ConflictLogger()
-...
-}
+const listener = new ConflictLogger()
+
+client.addConflictListener(listener)
 ```

--- a/packages/offix-client/src/apollo/conflicts/CompositeConflictListener.ts
+++ b/packages/offix-client/src/apollo/conflicts/CompositeConflictListener.ts
@@ -1,0 +1,38 @@
+import { ConflictListener, ConflictResolutionData } from "offix-conflicts-client";
+
+
+/**
+ * Composite Conflict Listener class that can accept register and remove individual listener functions as needed
+ * Gets passed down to the conflict link
+ */
+export class CompositeConflictListener implements ConflictListener {
+
+  private listeners: ConflictListener[] = [];
+
+  addConflictListener(listener: ConflictListener) {
+    this.listeners.push(listener);
+  }
+
+  removeConflictListener(listener: ConflictListener) {
+    const index = this.listeners.indexOf(listener);
+    if (index >= 0) {
+      this.listeners.splice(index, 1);
+    }
+  }
+
+  mergeOccurred(operationName: string, resolvedData: ConflictResolutionData, server: ConflictResolutionData, client: ConflictResolutionData) {
+    for (const listener of this.listeners) {
+      if (listener.mergeOccurred) {
+        listener.mergeOccurred(operationName, resolvedData, server, client);
+      }
+    }
+  }
+
+  conflictOccurred(operationName: string, resolvedData: ConflictResolutionData, server: ConflictResolutionData, client: ConflictResolutionData) {
+    for (const listener of this.listeners) {
+      if (listener.conflictOccurred) {
+        listener.conflictOccurred(operationName, resolvedData, server, client);
+      }
+    }
+  }
+}

--- a/packages/offix-client/src/apollo/index.ts
+++ b/packages/offix-client/src/apollo/index.ts
@@ -4,3 +4,4 @@ export * from "./LinksBuilder";
 export * from "./optimisticResponseHelpers";
 export * from "./conflicts/baseHelpers";
 export * from "./conflicts/ConflictLink";
+export * from "./conflicts/CompositeConflictListener";

--- a/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
+++ b/packages/offix-client/src/config/ApolloOfflineClientConfig.ts
@@ -7,7 +7,6 @@ import { ApolloOfflineClientOptions, InputMapper } from "./ApolloOfflineClientOp
 import { NetworkStatus } from "offix-offline";
 import {
   ConflictResolutionStrategy,
-  ConflictListener,
   UseClient,
   VersionedState,
   ObjectState
@@ -15,7 +14,7 @@ import {
 import { createDefaultCacheStorage } from "../cache";
 import { ApolloLink } from "apollo-link";
 import { CacheUpdates } from "offix-cache";
-import { ApolloOfflineQueueListener, createDefaultLink } from "../apollo";
+import { ApolloOfflineQueueListener, createDefaultLink, CompositeConflictListener } from "../apollo";
 import { CachePersistor } from "apollo-cache-persist";
 
 /**
@@ -31,7 +30,7 @@ export class ApolloOfflineClientConfig implements ApolloOfflineClientOptions {
   public terminatingLink: ApolloLink | undefined;
   public cacheStorage: PersistentStore<PersistedData>;
   public offlineStorage: PersistentStore<PersistedData>;
-  public conflictListener?: ConflictListener;
+  public conflictListener: CompositeConflictListener;
   public mutationCacheUpdates?: CacheUpdates;
   public cachePersistor?: CachePersistor<object>;
   public link?: ApolloLink;
@@ -56,6 +55,10 @@ export class ApolloOfflineClientConfig implements ApolloOfflineClientOptions {
     this.offlineStorage = options.offlineStorage || createDefaultOfflineStorage();
     this.conflictStrategy = options.conflictStrategy || UseClient;
     this.conflictProvider = options.conflictProvider || new VersionedState();
+    this.conflictListener = new CompositeConflictListener();
+    if (options.conflictListener) {
+      this.conflictListener.addConflictListener(options.conflictListener);
+    }
     this.link = createDefaultLink(this);
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->


Adds a `CompositeConflictListener` class that always gets passed down to the `ConflictLink`. This allows us to add/remove listeners as needed. It's quick and dirty but it works and it has an integration test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
