### PR TITLE
Fix problem with multiple subscribers

### DIFF
--- a/packages/offix-datastore/src/utils/PushStream.ts
+++ b/packages/offix-datastore/src/utils/PushStream.ts
@@ -11,18 +11,16 @@ export interface PushStream<T> {
 
 export class ObservablePushStream<T> implements PushStream<T> {
     private observable: Observable<T>;
-    private observer: any;
+    private observers: any[] = [];
 
     constructor() {
         this.observable = new Observable(observer => {
-            this.observer = observer;
+            this.observers.push(observer);
         });
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        this.observable.subscribe((e) => {});
     }
 
     public push(message: T) {
-        this.observer.next(message);
+        this.observers.forEach(o => o.next(message));
     }
 
     public subscribe(listener: (message: T) => void) {

--- a/packages/offix-datastore/tests/DataStore.test.ts
+++ b/packages/offix-datastore/tests/DataStore.test.ts
@@ -144,13 +144,18 @@ test("Remove all entities matching predicate from local store", async () => {
 
 test("Observe local store events", async () => {
     const note = { title: "test", description: "description" };
-    expect.assertions(2);
+    expect.assertions(3);
 
     NoteModel.on("ADD", (event) => {
         expect(event.eventType).toEqual("ADD");
         expect(event.data.title).toEqual(note.title);
     });
+    NoteModel.on("UPDATE", (event) => {
+        expect(event.eventType).toEqual("UPDATE");
+    });
+
     await NoteModel.save(note);
+    await NoteModel.update({ title: "changed" }, (p) => p.title("eq", "test"));
 });
 
 test("Push local change to server", (done) => {


### PR DESCRIPTION
### Description

Previous subscribers to Storage stream are overwritten when a new one is added. I have added a fix that collects all observers in an array which solves the problem. I update the "Observe local store for changes" test in `DataStore.test.ts` to include two subscriptions to verify that the fix works. 

##### Checklist

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
