### PR TITLE
fix: allow to use offline change without optimistic response

### DIFF
--- a/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
+++ b/packages/offix-client/src/apollo/optimisticResponseHelpers.ts
@@ -29,7 +29,7 @@ export function restoreOptimisticResponse(
   apolloClient: ApolloClient<NormalizedCacheObject>,
   mutationCacheUpdates: CacheUpdates,
   { op, qid }: ApolloQueueEntryOperation) {
-  if (op.context.operationName && mutationCacheUpdates[op.context.operationName]) {
+  if (op?.context?.operationName && mutationCacheUpdates[op.context.operationName]) {
     op.update = mutationCacheUpdates[op.context.operationName];
     addOptimisticResponse(apolloClient, { op, qid });
   }


### PR DESCRIPTION
Even driven engine messes things up - it tries to restore changes that replication already removed. 

<img width="323" alt="Screenshot 2020-07-07 at 16 20 11" src="https://user-images.githubusercontent.com/981838/86803284-bf334d00-c06d-11ea-9d81-eb96d4f674b4.png">

<img width="454" alt="Screenshot 2020-07-07 at 16 20 09" src="https://user-images.githubusercontent.com/981838/86803517-f7d32680-c06d-11ea-9ce0-ab28abb7ade3.png">

This fix patches the problem to avoid breaking client. However entire event driven locking need to be done - in separate PR
