### PR TITLE
fix: add graphql-crud compatible queries

### DIFF
--- a/packages/offix-datastore/src/replication/GraphQLCrudQueryBuilder.ts
+++ b/packages/offix-datastore/src/replication/GraphQLCrudQueryBuilder.ts
@@ -10,42 +10,91 @@ import { Model } from "../Model";
 // TODO add deltaqueries/subscriptions
 // TODO have static/precompiled gql queries instead of processing all at runtime
 export class GraphQLCrudQueryBuilder implements GraphQLQueryBuilder {
-    build(models: Model<any>[]): Map<string, GraphQLQueries> {
-        const queriesMap: Map<string, GraphQLQueries> = new Map();
+  build(models: Model<any>[]): Map<string, GraphQLQueries> {
+    const queriesMap: Map<string, GraphQLQueries> = new Map();
 
-        models.forEach((model) => {
-            const fields = model.getFields();
-            const fieldsBuilder: string[] = Object.keys(fields).map((key) => {
-                const graphQLKey = fields[key].key;
-                return graphQLKey;
-            });
-            const graphQLFields = fieldsBuilder.join("\n");
-            const modelName = model.getName();
+    models.forEach((model) => {
+      const fields = model.getFields();
+      const fieldsBuilder: string[] = Object.keys(fields).map((key) => {
+        const graphQLKey = fields[key].key;
+        return graphQLKey;
+      });
+      const graphQLFields = fieldsBuilder.join("\n");
+      const modelName = model.getName();
 
-            const mutations = {
-                create: gql`
+      const mutations = {
+        create: gql`
                 mutation create${modelName}($input: Create${modelName}Input!) {
                     create${modelName}(input: $input) {
                         ${graphQLFields}
                     }
                 }`,
-                update: gql`
+        update: gql`
                 mutation update${modelName}($input: Mutate${modelName}Input!) {
                     update${modelName}(input: $input) {
                         ${graphQLFields}
                     }
                 }`,
-                delete: gql`
+        delete: gql`
                 mutation delete${modelName}($input: Mutate${modelName}Input!) {
                     delete${modelName}(input: $input) {
                         ${graphQLFields}
                     }
                 }`
-            };
+      };
 
-            queriesMap.set(model.getStoreName(), { mutations });
-        });
+      const queries = {
+        // TODO this requires using pluralize as plural form will not always be the same.
+        find: gql`
+            query find${modelName}($filter: ${modelName}Filter, $page: PageRequest, $orderBy: OrderByInput) {
+              find${modelName}s(filter: $filter, page: $page, orderBy: $orderBy) {
+                  items {
+                    ${graphQLFields}
+                  }
+                  offset
+                  limit
+              }
+            }`,
+        sync: gql`
+                query sync${modelName}($lastChanged: String!, $filter: ${modelName}Filter) {
+                  find${modelName}s(lastChanged: $lastChanged, filter: $filter) {
+                      items {
+                        ${graphQLFields}
+                      }
+                      lastChanged
+                  }
+                }`,
+        get: gql`
+            query get${modelName}($input: Mutate${modelName}Input!) {
+                update${modelName}(input: $input) {
+                    ${graphQLFields}
+                }
+            }`
+      };
 
-        return queriesMap;
-    }
+      const subscriptions = {
+        create: gql`
+            mutation new${modelName}($input: ${modelName}SubscriptionFilter) {
+                new${modelName}(input: $input) {
+                    ${graphQLFields}
+                }
+            }`,
+        update: gql`
+            mutation updated${modelName}($input: ${modelName}SubscriptionFilter) {
+              updated${modelName}(input: $input) {
+                    ${graphQLFields}
+                }
+            }`,
+        delete: gql`
+            mutation deleted${modelName}($input: ${modelName}SubscriptionFilter) {
+                delete${modelName}(input: $input) {
+                    ${graphQLFields}
+                }
+            }`
+      };
+      queriesMap.set(model.getStoreName(), { mutations, subscriptions, queries });
+    });
+
+    return queriesMap;
+  }
 }

--- a/packages/offix-datastore/src/replication/GraphQLCrudQueryBuilder.ts
+++ b/packages/offix-datastore/src/replication/GraphQLCrudQueryBuilder.ts
@@ -73,19 +73,19 @@ export class GraphQLCrudQueryBuilder implements GraphQLQueryBuilder {
       };
 
       const subscriptions = {
-        create: gql`
+        new: gql`
             mutation new${modelName}($input: ${modelName}SubscriptionFilter) {
                 new${modelName}(input: $input) {
                     ${graphQLFields}
                 }
             }`,
-        update: gql`
+        updated: gql`
             mutation updated${modelName}($input: ${modelName}SubscriptionFilter) {
               updated${modelName}(input: $input) {
                     ${graphQLFields}
                 }
             }`,
-        delete: gql`
+        deleted: gql`
             mutation deleted${modelName}($input: ${modelName}SubscriptionFilter) {
                 delete${modelName}(input: $input) {
                     ${graphQLFields}

--- a/packages/offix-datastore/src/replication/GraphQLReplicator.ts
+++ b/packages/offix-datastore/src/replication/GraphQLReplicator.ts
@@ -7,7 +7,7 @@ import { DatabaseEvents } from "../storage";
 /**
  * GraphQL mutations for create, update and delete
  */
-export interface Mutations {
+export interface ReplicatorMutations {
     /**
      * GraphQL create mutation document.
      * It takes an input variable which is the entity to be created
@@ -29,10 +29,45 @@ export interface Mutations {
     delete: string | DocumentNode;
 }
 
+/**
+ * GraphQL mutations for create, update and delete
+ */
+export interface ReplicatorSubscriptions {
+  /**
+   * GraphQL create subscription document.
+   */
+  new: string | DocumentNode;
+
+  /**
+   * GraphQL update subscription document.
+   */
+  updated: string | DocumentNode;
+
+  /**
+   * GraphQL delete subscription document.
+   */
+  deleted: string | DocumentNode;
+}
+
+/**
+ * GraphQL mutations for create, update and delete
+ */
+export interface ReplicatorQueries {
+  /**
+   * FindQuery used to fetch data
+   */
+  find: string | DocumentNode;
+
+  /**
+   * GraphQL get operation
+   */
+  get: string | DocumentNode;
+}
+
 export interface GraphQLQueries {
-    // TODO queries;
-    mutations: Mutations;
-    // TODO subsrciptions
+    queries: ReplicatorQueries;
+    mutations: ReplicatorMutations;
+    subscriptions: ReplicatorSubscriptions;
 }
 /**
  * A GraphQLClient to communicate with the GraphQLAPI

--- a/packages/offix-datastore/tests/__snapshots__/GraphQLReplication.test.ts.snap
+++ b/packages/offix-datastore/tests/__snapshots__/GraphQLReplication.test.ts.snap
@@ -301,5 +301,753 @@ Object {
       },
     },
   },
+  "queries": Object {
+    "find": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "findTest",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "filter",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "filter",
+                      },
+                    },
+                  },
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "page",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "page",
+                      },
+                    },
+                  },
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "orderBy",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "orderBy",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "findTests",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "items",
+                      },
+                      "selectionSet": Object {
+                        "kind": "SelectionSet",
+                        "selections": Array [
+                          Object {
+                            "alias": undefined,
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "id",
+                            },
+                            "selectionSet": undefined,
+                          },
+                          Object {
+                            "alias": undefined,
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "title",
+                            },
+                            "selectionSet": undefined,
+                          },
+                        ],
+                      },
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "offset",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "limit",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "TestFilter",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "filter",
+                },
+              },
+            },
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "PageRequest",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "page",
+                },
+              },
+            },
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "OrderByInput",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "orderBy",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 323,
+        "start": 0,
+      },
+    },
+    "get": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "getTest",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "input",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "input",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "updateTest",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "title",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NonNullType",
+                "type": Object {
+                  "kind": "NamedType",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "MutateTestInput",
+                  },
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "input",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 159,
+        "start": 0,
+      },
+    },
+    "sync": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "syncTest",
+          },
+          "operation": "query",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "lastChanged",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "lastChanged",
+                      },
+                    },
+                  },
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "filter",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "filter",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "findTests",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "items",
+                      },
+                      "selectionSet": Object {
+                        "kind": "SelectionSet",
+                        "selections": Array [
+                          Object {
+                            "alias": undefined,
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "id",
+                            },
+                            "selectionSet": undefined,
+                          },
+                          Object {
+                            "alias": undefined,
+                            "arguments": Array [],
+                            "directives": Array [],
+                            "kind": "Field",
+                            "name": Object {
+                              "kind": "Name",
+                              "value": "title",
+                            },
+                            "selectionSet": undefined,
+                          },
+                        ],
+                      },
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "lastChanged",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NonNullType",
+                "type": Object {
+                  "kind": "NamedType",
+                  "name": Object {
+                    "kind": "Name",
+                    "value": "String",
+                  },
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "lastChanged",
+                },
+              },
+            },
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "TestFilter",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "filter",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 310,
+        "start": 0,
+      },
+    },
+  },
+  "subscriptions": Object {
+    "deleted": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "deletedTest",
+          },
+          "operation": "mutation",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "input",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "input",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "deleteTest",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "title",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "TestSubscriptionFilter",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "input",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 172,
+        "start": 0,
+      },
+    },
+    "new": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "newTest",
+          },
+          "operation": "mutation",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "input",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "input",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "newTest",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "title",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "TestSubscriptionFilter",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "input",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 165,
+        "start": 0,
+      },
+    },
+    "updated": Object {
+      "definitions": Array [
+        Object {
+          "directives": Array [],
+          "kind": "OperationDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "updatedTest",
+          },
+          "operation": "mutation",
+          "selectionSet": Object {
+            "kind": "SelectionSet",
+            "selections": Array [
+              Object {
+                "alias": undefined,
+                "arguments": Array [
+                  Object {
+                    "kind": "Argument",
+                    "name": Object {
+                      "kind": "Name",
+                      "value": "input",
+                    },
+                    "value": Object {
+                      "kind": "Variable",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "input",
+                      },
+                    },
+                  },
+                ],
+                "directives": Array [],
+                "kind": "Field",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "updatedTest",
+                },
+                "selectionSet": Object {
+                  "kind": "SelectionSet",
+                  "selections": Array [
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "id",
+                      },
+                      "selectionSet": undefined,
+                    },
+                    Object {
+                      "alias": undefined,
+                      "arguments": Array [],
+                      "directives": Array [],
+                      "kind": "Field",
+                      "name": Object {
+                        "kind": "Name",
+                        "value": "title",
+                      },
+                      "selectionSet": undefined,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          "variableDefinitions": Array [
+            Object {
+              "defaultValue": undefined,
+              "directives": Array [],
+              "kind": "VariableDefinition",
+              "type": Object {
+                "kind": "NamedType",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "TestSubscriptionFilter",
+                },
+              },
+              "variable": Object {
+                "kind": "Variable",
+                "name": Object {
+                  "kind": "Name",
+                  "value": "input",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "kind": "Document",
+      "loc": Object {
+        "end": 171,
+        "start": 0,
+      },
+    },
+  },
 }
 `;


### PR DESCRIPTION
Adding first part of the work that will add graphqlcrud queries. 
There is problem with probability - names are not deterministic. 
We need to resolve that separately and possibly using single tooling to generate static resources. 

Going to continue work on this to explore how we fetch data first and then focus on edits.