### PR TITLE
Typesafe and complete operators closes #580

### DIFF
--- a/docs/ref-datastore-manipulating-data.md
+++ b/docs/ref-datastore-manipulating-data.md
@@ -34,9 +34,17 @@ TaskModel.query((p) => p.title("eq", "test"))
 .then((data) => {}) // Retrieves all tasks where title matches "test"
 ```
 
-Currently supported operators(more coming soon)
-- eq  equality operator
-- gt  greater than operator
+Supported operators
+- 'ne' - Is value not equal to input
+- 'eq' - Is value equal to input
+- 'le' - Is value less than or equal to input
+- 'lt' - Is value strictly less than input
+- 'ge' - Is value greater than or equal to input
+- 'gt' - Is value strictly greater than input
+- 'in' - Does input array or string contain value
+- 'contains' - Is the input contained in value(array or string)
+- 'startsWith' - Does value start with input string
+- 'endsWith' - Does value end with input string
 
 You can also create expressions with the following logical operators  
 `and | or | not`

--- a/docs/ref-datastore-manipulating-data.md
+++ b/docs/ref-datastore-manipulating-data.md
@@ -34,7 +34,7 @@ TaskModel.query((p) => p.title("eq", "test"))
 .then((data) => {}) // Retrieves all tasks where title matches "test"
 ```
 
-Supported operators
+All supported operators
 - 'ne' - Is value not equal to input
 - 'eq' - Is value equal to input
 - 'le' - Is value less than or equal to input
@@ -42,9 +42,16 @@ Supported operators
 - 'ge' - Is value greater than or equal to input
 - 'gt' - Is value strictly greater than input
 - 'in' - Does input array or string contain value
-- 'contains' - Is the input contained in value(array or string)
-- 'startsWith' - Does value start with input string
-- 'endsWith' - Does value end with input string
+- 'contains' - Is the input contained in value
+- 'startsWith' - Does value start with input
+- 'endsWith' - Does value end with input
+
+String Operators: "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in" | "contains" | "startsWith" | "endsWith"
+Number Operators "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in"
+Boolean Operators: "ne" | "eq" | "in"
+Date Operators: "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in"
+
+All array types also support the "contains" operator.
 
 You can also create expressions with the following logical operators  
 `and | or | not`

--- a/docs/ref-datastore-manipulating-data.md
+++ b/docs/ref-datastore-manipulating-data.md
@@ -50,8 +50,7 @@ String Operators: "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in" | "contains" | 
 Number Operators "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in"
 Boolean Operators: "ne" | "eq" | "in"
 Date Operators: "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in"
-
-All array types also support the "contains" operator.
+Arrays: "ne" | "eq" | "in" | "contains"
 
 You can also create expressions with the following logical operators  
 `and | or | not`

--- a/packages/offix-datastore/src/DataStore.ts
+++ b/packages/offix-datastore/src/DataStore.ts
@@ -25,7 +25,7 @@ export interface DataStoreConfig {
 export class DataStore {
     private dbName: string;
     private schemaVersion: number;
-    private models: Model<any>[];
+    private models: Model<unknown>[];
     private storage?: Storage;
     private url: string;
 

--- a/packages/offix-datastore/src/Model.ts
+++ b/packages/offix-datastore/src/Model.ts
@@ -20,7 +20,7 @@ export type Fields<T> = {
 /**
  * Provides CRUD capabilities for a model
  */
-export class Model<T> {
+export class Model<T = unknown> {
     private name: string;
     private storeName: string;
     private fields: Fields<T>;

--- a/packages/offix-datastore/src/predicates/Operators.ts
+++ b/packages/offix-datastore/src/predicates/Operators.ts
@@ -1,10 +1,40 @@
-const equalsOperator = (modelField: any, value: any) => modelField === value;
-const gtOperator = (modelField: any, value: any) => modelField > value;
+type CommonOperators = 'ne' | 'eq' | 'le' | 'lt' | 'ge' | 'gt';
 
-// https://github.com/aerogear/OpenVolunteerPlatform/blob/master/platform/client/src/dataFacade.tsx
-// TODO ADD type safety
-// TODO align operators to graphqlcrud
-export const AllOperators: any = {
-    "eq": equalsOperator,
-    "gt": gtOperator
+/**
+ * All Operators
+ * 
+ * 'ne' - Is value not equal to input
+ * 'eq' - Is value equal to input
+ * 'le' - Is value less than or equal to input
+ * 'lt' - Is value strictly less than input
+ * 'ge' - Is value greater than or equal to input
+ * 'gt' - Is value strictly greater than input
+ * 'in' - Does input array or string contain value
+ * 'contains' - Is the input contained in value(array or string)
+ * 'startsWith' - Does value start with input string
+ * 'endsWith' - Does value end with input string
+ */
+export type AllOperators = CommonOperators | 'in' | 'contains' | 'startsWith' | 'endsWith';
+
+/**
+ * Maps data type to allowed operators
+ */
+export type TypeOperatorMap<T> = 
+    T extends string ? AllOperators :
+    T extends number ? CommonOperators :
+    T extends boolean ? 'ne' | 'eq' :
+    T extends Date ? CommonOperators :
+    AllOperators;
+
+export const OperatorFunctionMap = {
+    ne: (m: any, v: any) => m !== v,
+    eq: (m: any, v: any) => m === v,
+    ge: (m: number | string | Date, v: number | string | Date) => m >= v,
+    gt: (m: number | string | Date, v: number | string | Date) => m > v,
+    le: (m: number | string | Date, v: number | string | Date) => m <= v,
+    lt: (m: number | string | Date, v: number | string | Date) => m < v,
+    in: (m: any, v: any[] | string) => v.includes(m),
+    contains: (m: any[] | string, v: string) => m.includes(v),
+    startsWith: (m: string, v: string) => m.startsWith(v),
+    endsWith: (m: string, v: string) => m.endsWith(v)
 };

--- a/packages/offix-datastore/src/predicates/Operators.ts
+++ b/packages/offix-datastore/src/predicates/Operators.ts
@@ -1,4 +1,4 @@
-type CommonOperators = "ne" | "eq" | "le" | "lt" | "ge" | "gt";
+type CommonOperators = "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in";
 
 /**
  * All Operators
@@ -14,15 +14,18 @@ type CommonOperators = "ne" | "eq" | "le" | "lt" | "ge" | "gt";
  * 'startsWith' - Does value start with input string
  * 'endsWith' - Does value end with input string
  */
-export type AllOperators = CommonOperators | "in" | "contains" | "startsWith" | "endsWith";
+export type AllOperators = CommonOperators | "contains" | "startsWith" | "endsWith";
 
 /**
  * Maps data type to allowed operators
  */
 export type TypeOperatorMap<T> =
     T extends string ? AllOperators :
+    T extends number[] ? CommonOperators | "contains" :
     T extends number ? CommonOperators :
-    T extends boolean ? "ne" | "eq" :
+    T extends boolean[] ? "ne" | "eq" | "in" | "contains" :
+    T extends boolean ? "ne" | "eq" | "in" :
+    T extends Date[] ? CommonOperators | "contains" :
     T extends Date ? CommonOperators :
     AllOperators;
 

--- a/packages/offix-datastore/src/predicates/Operators.ts
+++ b/packages/offix-datastore/src/predicates/Operators.ts
@@ -1,4 +1,5 @@
-type CommonOperators = "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in";
+type ArrayOperators = "ne" | "eq" | "in" | "contains";
+type MathematicalOperators = "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in";
 
 /**
  * All Operators
@@ -14,19 +15,17 @@ type CommonOperators = "ne" | "eq" | "le" | "lt" | "ge" | "gt" | "in";
  * 'startsWith' - Does value start with input string
  * 'endsWith' - Does value end with input string
  */
-export type AllOperators = CommonOperators | "contains" | "startsWith" | "endsWith";
+export type AllOperators = MathematicalOperators | "contains" | "startsWith" | "endsWith";
 
 /**
  * Maps data type to allowed operators
  */
 export type TypeOperatorMap<T> =
+    T extends Array<any> ? ArrayOperators :
     T extends string ? AllOperators :
-    T extends number[] ? CommonOperators | "contains" :
-    T extends number ? CommonOperators :
-    T extends boolean[] ? "ne" | "eq" | "in" | "contains" :
+    T extends number ? MathematicalOperators :
     T extends boolean ? "ne" | "eq" | "in" :
-    T extends Date[] ? CommonOperators | "contains" :
-    T extends Date ? CommonOperators :
+    T extends Date ? MathematicalOperators :
     AllOperators;
 
 export const OperatorFunctionMap = {

--- a/packages/offix-datastore/src/predicates/Operators.ts
+++ b/packages/offix-datastore/src/predicates/Operators.ts
@@ -1,8 +1,8 @@
-type CommonOperators = 'ne' | 'eq' | 'le' | 'lt' | 'ge' | 'gt';
+type CommonOperators = "ne" | "eq" | "le" | "lt" | "ge" | "gt";
 
 /**
  * All Operators
- * 
+ *
  * 'ne' - Is value not equal to input
  * 'eq' - Is value equal to input
  * 'le' - Is value less than or equal to input
@@ -14,15 +14,15 @@ type CommonOperators = 'ne' | 'eq' | 'le' | 'lt' | 'ge' | 'gt';
  * 'startsWith' - Does value start with input string
  * 'endsWith' - Does value end with input string
  */
-export type AllOperators = CommonOperators | 'in' | 'contains' | 'startsWith' | 'endsWith';
+export type AllOperators = CommonOperators | "in" | "contains" | "startsWith" | "endsWith";
 
 /**
  * Maps data type to allowed operators
  */
-export type TypeOperatorMap<T> = 
+export type TypeOperatorMap<T> =
     T extends string ? AllOperators :
     T extends number ? CommonOperators :
-    T extends boolean ? 'ne' | 'eq' :
+    T extends boolean ? "ne" | "eq" :
     T extends Date ? CommonOperators :
     AllOperators;
 

--- a/packages/offix-datastore/src/predicates/Predicates.ts
+++ b/packages/offix-datastore/src/predicates/Predicates.ts
@@ -1,12 +1,12 @@
 import { ExpressionOperators, ModelFieldPredicate, PredicateExpression, PredicateFunction } from "./PredicateFunctions";
-import { AllOperators } from "./Operators";
+import { OperatorFunctionMap, TypeOperatorMap, AllOperators } from "./Operators";
 import { Fields } from "../Model";
 
 /**
  * Defines the fields that can be used for filtering in a predicate for a given type
  */
 export type ModelPredicate<T> = {
-    [P in keyof Required<T>]: (op: string, value: T[P]) => ModelFieldPredicate
+    [P in keyof Required<T>]: (op: TypeOperatorMap<T[P]>, input: T[P] | T[P][]) => ModelFieldPredicate
 } & {
     or: (...predicates: PredicateFunction[]) => PredicateExpression;
     and: (...predicates: PredicateFunction[]) => PredicateExpression;
@@ -27,7 +27,7 @@ export function createPredicate<T>(fields: Fields<T>): ModelPredicate<T> {
     const modelPredicate: any = {};
 
     Object.keys(fields).forEach((key: string) => {
-        modelPredicate[key] = (op: string, value: any) => new ModelFieldPredicate(key, value, AllOperators[op]);
+        modelPredicate[key] = (op: AllOperators, input: any) => new ModelFieldPredicate(key, input, OperatorFunctionMap[op]);
     });
 
     modelPredicate.or = (...predicates: any[]) => {

--- a/packages/offix-datastore/src/predicates/Predicates.ts
+++ b/packages/offix-datastore/src/predicates/Predicates.ts
@@ -5,7 +5,7 @@ import { Fields } from "../Model";
 /**
  * Defines the fields that can be used for filtering in a predicate for a given type
  */
-export type ModelPredicate<T> = {
+export type ModelPredicate<T = any> = {
     [P in keyof Required<T>]: (op: TypeOperatorMap<T[P]>, input: T[P] | T[P][]) => ModelFieldPredicate
 } & {
     or: (...predicates: PredicateFunction[]) => PredicateExpression;

--- a/packages/offix-datastore/src/replication/GraphQLCrudQueryBuilder.ts
+++ b/packages/offix-datastore/src/replication/GraphQLCrudQueryBuilder.ts
@@ -10,17 +10,17 @@ import { Model } from "../Model";
 // TODO add deltaqueries/subscriptions
 // TODO have static/precompiled gql queries instead of processing all at runtime
 export class GraphQLCrudQueryBuilder implements GraphQLQueryBuilder {
-  build(models: Model<any>[]): Map<string, GraphQLQueries> {
-    const queriesMap: Map<string, GraphQLQueries> = new Map();
+    build(models: Model[]): Map<string, GraphQLQueries> {
+        const queriesMap: Map<string, GraphQLQueries> = new Map();
 
-    models.forEach((model) => {
-      const fields = model.getFields();
-      const fieldsBuilder: string[] = Object.keys(fields).map((key) => {
-        const graphQLKey = fields[key].key;
-        return graphQLKey;
-      });
-      const graphQLFields = fieldsBuilder.join("\n");
-      const modelName = model.getName();
+        models.forEach((model) => {
+            const fields: any = model.getFields();
+            const fieldsBuilder: string[] = Object.keys(fields).map((key) => {
+                const graphQLKey = fields[key].key;
+                return graphQLKey;
+            });
+            const graphQLFields = fieldsBuilder.join("\n");
+            const modelName = model.getName();
 
       const mutations = {
         create: gql`

--- a/packages/offix-datastore/src/storage/Storage.ts
+++ b/packages/offix-datastore/src/storage/Storage.ts
@@ -97,7 +97,7 @@ export class Storage {
     public readonly storeChangeEventStream: PushStream<StoreChangeEvent>;
     private adapter: IStorageAdapter;
 
-    constructor(dbName: string, models: Model<any>[], schemaVersion: number) {
+    constructor(dbName: string, models: Model[], schemaVersion: number) {
         this.storeChangeEventStream = new ObservablePushStream();
         this.adapter = createDefaultStorage(dbName, models, schemaVersion);
     }

--- a/packages/offix-datastore/src/storage/adapters/IndexedDBStorage.ts
+++ b/packages/offix-datastore/src/storage/adapters/IndexedDBStorage.ts
@@ -8,7 +8,7 @@ import { Model } from "../../Model";
 export class IndexedDBStorage implements IStorageAdapter {
     private indexedDB: Promise<IDBDatabase>;
 
-    constructor(dbName: string, models: Model<any>[], schemaVersion: number) {
+    constructor(dbName: string, models: Model[], schemaVersion: number) {
         this.indexedDB = new Promise((resolve, reject) => {
             const openreq = indexedDB.open(dbName, schemaVersion);
             openreq.onerror = () => reject(openreq.error);

--- a/packages/offix-datastore/src/storage/adapters/defaultStorage.ts
+++ b/packages/offix-datastore/src/storage/adapters/defaultStorage.ts
@@ -1,6 +1,6 @@
 import { IndexedDBStorage } from "./IndexedDBStorage";
 import { Model } from "../../Model";
 
-export function createDefaultStorage(dbName: string, models: Model<any>[], schemaVersion: number) {
+export function createDefaultStorage(dbName: string, models: Model[], schemaVersion: number) {
     return new IndexedDBStorage(dbName, models, schemaVersion);
 }


### PR DESCRIPTION
### Description

Implemented all the operators used in [GraphQLCrud filters](https://graphqlcrud.org/docs/next/find/#filtering). I modified Predicates such that the type of a field determines the allowed operators for that field. For example, numbers cannot use the "startsWith" operator. Also, only values of the same type or type[] can be compared. For example, you can perform the greater than operation on two numbers, not a number and a string.
 
##### Checklist

- [x] `npm test` passes
- [x] `npm run build` works
- [x] documentation is changed or added
