### PR TITLE
Fix broken link in ref-configuration.md

### DIFF
--- a/docs/ref-configuration.md
+++ b/docs/ref-configuration.md
@@ -132,6 +132,6 @@ const client = new ApolloOfflineClient({
 * `httpUrl` (required) - The URL of the GraphQL server
 * `wsUrl` (required) - The URL of the websocket endpoint for subscriptions
 * `cache` - The Apollo [InMemoryCache](https://www.apollographql.com/docs/react/caching/cache-configuration/) that will be used. (creates one by default).
-* `authContextProvider` - An object or an `async` function that returns an [`AuthContext`](https://github.com/aerogear/offix/blob/master/packages/offix-client-boost/src/auth/AuthContexrProvider.ts) object with authentication headers that will be passed in GraphQL requests and in the `connectionParams` of websocket connections.
+* `authContextProvider` - An object or an `async` function that returns an [`AuthContext`](https://github.com/aerogear/offix/blob/master/packages/offix-client-boost/src/auth/AuthContextProvider.ts) object with authentication headers that will be passed in GraphQL requests and in the `connectionParams` of websocket connections.
 * `fileUpload` - If set to `true`, GraphGL file uploads will be enabled and supported. (default is `false`)
 * `websocketClientOptions` - Options for the websocket client used for subscriptions. See [subscriptions-transport-ws](https://www.npmjs.com/package/subscriptions-transport-ws)


### PR DESCRIPTION
### Description

The URL to AuthContext in the description of the `authContextProvider` option for the offix-client-boost createClient function has a typo.


##### Checklist

- [x] documentation is changed or added
