### PR TITLE
Predicate filter conversion

### DIFF
--- a/packages/offix-datastore/src/Model.ts
+++ b/packages/offix-datastore/src/Model.ts
@@ -153,7 +153,12 @@ export class Model<T = unknown> {
   private async doDeltaSync(replicator: IReplicator, matcher: (d: T) => Predicate<T>, predicate?: Predicate<T>) {
     // TODO limit the size of data returned
     // TODO get lastSync for model for metadata store and pass to pullDelta
-    const data = await replicator.pullDelta(this.getStoreName(), "", predicate);
+    const modelPredicate = createPredicate(this.fields);
+    const data = await replicator.pullDelta(
+      this.getStoreName(),
+      "",
+      (predicate ? predicate(modelPredicate) : undefined)
+    );
     if (data.errors) {
       // TODO handle errors;
       // eslint-disable-next-line no-console

--- a/packages/offix-datastore/src/predicates/Operators.ts
+++ b/packages/offix-datastore/src/predicates/Operators.ts
@@ -28,15 +28,25 @@ export type TypeOperatorMap<T> =
     T extends Date ? MathematicalOperators :
     AllOperators;
 
+export class Operator {
+    public readonly op: string;
+    public readonly opFunction: (m: any, v: any) => boolean;
+
+    constructor(op: string, opFunction: (m: any, v: any) => boolean) {
+        this.op = op;
+        this.opFunction = opFunction;
+    }
+}
+
 export const OperatorFunctionMap = {
-    ne: (m: any, v: any) => m !== v,
-    eq: (m: any, v: any) => m === v,
-    ge: (m: number | string | Date, v: number | string | Date) => m >= v,
-    gt: (m: number | string | Date, v: number | string | Date) => m > v,
-    le: (m: number | string | Date, v: number | string | Date) => m <= v,
-    lt: (m: number | string | Date, v: number | string | Date) => m < v,
-    in: (m: any, v: any[] | string) => v.includes(m),
-    contains: (m: any[] | string, v: string) => m.includes(v),
-    startsWith: (m: string, v: string) => m.startsWith(v),
-    endsWith: (m: string, v: string) => m.endsWith(v)
+    ne: new Operator("ne", (m: any, v: any) => m !== v),
+    eq: new Operator("eq", (m: any, v: any) => m === v),
+    ge: new Operator("ge", (m: number | string | Date, v: number | string | Date) => m >= v),
+    gt: new Operator("gt", (m: number | string | Date, v: number | string | Date) => m > v),
+    le: new Operator("le", (m: number | string | Date, v: number | string | Date) => m <= v),
+    lt: new Operator("lt", (m: number | string | Date, v: number | string | Date) => m < v),
+    in: new Operator("in", (m: any, v: any[] | string) => v.includes(m)),
+    contains: new Operator("contains", (m: any[] | string, v: string) => m.includes(v)),
+    startsWith: new Operator("startsWith", (m: string, v: string) => m.startsWith(v)),
+    endsWith: new Operator("endsWith", (m: string, v: string) => m.endsWith(v))
 };

--- a/packages/offix-datastore/src/predicates/PredicateFunctions.ts
+++ b/packages/offix-datastore/src/predicates/PredicateFunctions.ts
@@ -1,6 +1,8 @@
 // TODO evaluate how SQL Lite can be supported.
 // Capacitor or ReactNative or WebSQLLite
 
+import { Operator } from "./Operators";
+
 /**
  * A PredicateFunction filters data that match its conditions.
  * The conditions for any PredicateFunction is specified by overriding the evaluate method
@@ -22,12 +24,12 @@ export abstract class PredicateFunction {
 export class ModelFieldPredicate extends PredicateFunction {
     private key: string;
     private value: any;
-    private operator: Function;
+    private operator: Operator;
 
     constructor(
         key: string,
         value: any,
-        operator: Function
+        operator: Operator
     ) {
         super();
         this.key = key;
@@ -36,7 +38,7 @@ export class ModelFieldPredicate extends PredicateFunction {
     }
 
     public evaluate(model: any) {
-        return this.operator(model[this.key], this.value);
+        return this.operator.opFunction(model[this.key], this.value);
     }
 
     public getKey() {
@@ -57,6 +59,11 @@ export class ModelFieldPredicate extends PredicateFunction {
  */
 export interface ExpressionOperator {
     /**
+     * The name of the operator
+     */
+    op: string;
+
+    /**
      * Performs a logical operation on its inputs
      *
      * @param previousResult
@@ -68,16 +75,19 @@ export interface ExpressionOperator {
 
 export const ExpressionOperators = {
     or: {
+        op: "or",
         operate: (prevResult: boolean, currentResult: boolean) => {
             return prevResult || currentResult;
         }
     },
     and: {
+        op: "and",
         operate: (prevResult: boolean, currentResult: boolean) => {
             return prevResult && currentResult;
         }
     },
     not: {
+        op: "not",
         operate: (prevResult: boolean, currentResult: boolean) => {
             return !currentResult;
         }

--- a/packages/offix-datastore/src/predicates/PredicateFunctions.ts
+++ b/packages/offix-datastore/src/predicates/PredicateFunctions.ts
@@ -20,16 +20,35 @@ export abstract class PredicateFunction {
  * specified by the operator.
  */
 export class ModelFieldPredicate extends PredicateFunction {
+    private key: string;
+    private value: any;
+    private operator: Function;
+
     constructor(
-        private key: string,
-        private value: any,
-        private operator: Function
+        key: string,
+        value: any,
+        operator: Function
     ) {
         super();
+        this.key = key;
+        this.value = value;
+        this.operator = operator;
     }
 
     public evaluate(model: any) {
         return this.operator(model[this.key], this.value);
+    }
+
+    public getKey() {
+        return this.key;
+    }
+
+    public getValue() {
+        return this.value;
+    }
+
+    public getOperator() {
+        return this.operator;
     }
 }
 
@@ -71,11 +90,16 @@ export const ExpressionOperators = {
  * logical operation on two or more PredicateFunctions
  */
 export class PredicateExpression extends PredicateFunction {
+    private predicates: PredicateFunction[];
+    private operator: ExpressionOperator;
+
     constructor(
-        private predicates: PredicateFunction[],
-        private operator: ExpressionOperator
+        predicates: PredicateFunction[],
+        operator: ExpressionOperator
     ) {
         super();
+        this.predicates = predicates;
+        this.operator = operator;
     }
 
     public evaluate(model: any) {
@@ -86,5 +110,13 @@ export class PredicateExpression extends PredicateFunction {
         });
 
         return result;
+    }
+
+    public getPredicates() {
+        return this.predicates;
+    }
+
+    public getOperator() {
+        return this.operator;
     }
 }

--- a/packages/offix-datastore/src/replication/api/GraphQLClient.ts
+++ b/packages/offix-datastore/src/replication/api/GraphQLClient.ts
@@ -29,5 +29,5 @@ export interface GraphQLClient {
    * Subscriptions to a graphql server
    * @param query
    */
-  subscribe<T>(query: string | DocumentNode): Observable<T>;
+  subscribe<T>(query: string | DocumentNode, variables?: any): Observable<T>;
 }

--- a/packages/offix-datastore/src/replication/api/Replicator.ts
+++ b/packages/offix-datastore/src/replication/api/Replicator.ts
@@ -1,5 +1,5 @@
 import { CRUDEvents } from "../../storage";
-import { Predicate } from "../../predicates";
+import { PredicateFunction } from "../../predicates";
 import Observable from "zen-observable";
 import { GraphQLClientReponse } from "./GraphQLClient";
 
@@ -26,10 +26,10 @@ export interface IReplicator {
     /**
      * Pull changes from server since lastSync
      */
-    pullDelta<T>(storeName: string, lastSync: string, predicate?: Predicate<T>): Promise<GraphQLClientReponse<T>>;
+    pullDelta<T>(storeName: string, lastSync: string, predicate?: PredicateFunction): Promise<GraphQLClientReponse<T>>;
 
     /**
      * Subscribe to the changes on the server
      */
-    subscribe<T>(storeName: string, eventType: CRUDEvents,  predicate?: Predicate<T>): Observable<T>;
+    subscribe<T>(storeName: string, eventType: CRUDEvents,  predicate?: PredicateFunction): Observable<T>;
 }

--- a/packages/offix-datastore/src/replication/client/UrqlGraphQLClient.ts
+++ b/packages/offix-datastore/src/replication/client/UrqlGraphQLClient.ts
@@ -60,10 +60,10 @@ export class UrqlGraphQLClient implements GraphQLClient {
     }
   }
 
-  public subscribe<T>(query: DocumentNode) {
+  public subscribe<T>(query: DocumentNode, variables?: any) {
     return new Observable<T>(observer => {
       pipe(
-        this.client.subscription(query),
+        this.client.subscription(query, variables),
         subscribe(result => {
           if (result.error) {
             observer.error(result.error);

--- a/packages/offix-datastore/tests/GraphQLReplication.test.ts
+++ b/packages/offix-datastore/tests/GraphQLReplication.test.ts
@@ -2,7 +2,8 @@ import { DataStore } from "../src/DataStore";
 import { Model } from "../src/Model";
 import { CRUDEvents } from "../src/storage";
 import { GraphQLDocuments } from "../src/replication/api/Documents";
-import { buildGraphQLCRUDQueries, GraphQLCRUDReplicator } from "../src/replication";
+import { buildGraphQLCRUDQueries, GraphQLCRUDReplicator, convertPredicateToFilter } from "../src/replication";
+import { createPredicate } from "../src/predicates";
 
 let model: Model<any>;
 let queries: Map<string, GraphQLDocuments>;
@@ -48,5 +49,57 @@ test("Push mutation to GraphQL Server", (done) => {
     eventType: CRUDEvents.ADD,
     input,
     storeName: model.getStoreName()
+  });
+});
+
+describe("Predicate to GraphQL query conversion", () => {
+  test("Convert ModelField Predicates", () => {
+    const mp = createPredicate(model.getFields());
+    const predicateFunction = mp.title("eq", "test");
+    const result = convertPredicateToFilter(predicateFunction);
+    const expectedResult = {
+      title: { eq: "test" }
+    };
+    expect(result).toEqual(expectedResult);
+  });
+
+  test("Convert Expression Predicates", () => {
+    const mp = createPredicate(model.getFields());
+    const predicateFunction = mp.or(
+      mp.title("eq", "test"), mp.title("endsWith", "st"));
+    const result = convertPredicateToFilter(predicateFunction);
+    const expectedResult = {
+      or: [
+        { title: { eq: "test" } },
+        { title: { endsWith: "st" } }
+      ]
+    };
+    expect(result).toEqual(expectedResult);
+  });
+
+  test("Convert Expression of Expression Predicates", () => {
+    const mp = createPredicate(model.getFields());
+    const predicateFunction = mp.or(
+      mp.and(mp.title("eq", "test"), mp.title("endsWith", "st")),
+      mp.and(mp.title("eq", "test"), mp.title("startsWith", "ts"))
+    );
+    const result = convertPredicateToFilter(predicateFunction);
+    const expectedResult = {
+      or: [
+        {
+          and: [
+            { title: { eq: "test" } },
+            { title: { endsWith: "st" } }
+          ]
+        },
+        {
+          and: [
+            { title: { eq: "test" } },
+            { title: { startsWith: "ts" } }
+          ]
+        }
+      ]
+    };
+    expect(result).toEqual(expectedResult);
   });
 });

--- a/packages/offix-datastore/tests/Replication.test.ts
+++ b/packages/offix-datastore/tests/Replication.test.ts
@@ -15,6 +15,10 @@ const testFields = {
   id: {
     type: "ID",
     key: "id"
+  },
+  name: {
+    type: "String",
+    key: "name"
   }
 };
 const testMatcher = (d: any) => (p: any) => p.id("eq", d.id);


### PR DESCRIPTION
### Description

To enable predicate to filter conversion, I:
- modified Filter Operators and Expression Operators to include their op name not just the function
- the op name of these Operators are used in the graphql crud layer to create graphql crud compatible filters

To verify the predicate to filter conversion, simply run tests. I added a describe block with "predicate to filter" tests to GraphQLReplication tests 


##### Checklist

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
