### PR TITLE
Move events to model

### DIFF
--- a/examples/react-datastore/src/datasync/config.ts
+++ b/examples/react-datastore/src/datasync/config.ts
@@ -15,6 +15,6 @@ export const datastore = new DataStore({
   }
 });
 
-export const TodoModel = datastore.createModel<ITodo>(schema.Todo);
+export const TodoModel = datastore.setupModel<ITodo>(schema.Todo);
 
 datastore.init();

--- a/packages/offix-datastore/src/DataStore.ts
+++ b/packages/offix-datastore/src/DataStore.ts
@@ -6,6 +6,7 @@ import { IndexedDBStorageAdapter } from "./storage/adapters/IndexedDBStorageAdap
 import { ModelSchema, DataSyncJsonSchema } from "./ModelSchema";
 import { DataStoreConfig } from "./DataStoreConfig";
 import { createLogger, enableLogger } from "./utils/logger";
+import { ModelReplicationConfig } from "./replication/api/ReplicationConfig";
 
 const logger = createLogger("DataStore");
 // TODO disable logging before release
@@ -61,13 +62,23 @@ export class DataStore {
     }
   }
 
-  public createModel<T>(schema: DataSyncJsonSchema<T>) {
+  /**
+   * Initialize specific model using it's schema.
+   *
+   * @param schema - model schema containing fields and other details used to persist data
+   * @param replicationConfig optional override for replication configuration for this particular model
+   */
+  public setupModel<T>(schema: DataSyncJsonSchema<T>, replicationConfig?: ModelReplicationConfig) {
     const modelSchema = new ModelSchema(schema);
     const model = new Model<T>(modelSchema, this.storage);
-    this.replicator?.startModelReplication(model, this.storage);
+    this.replicator?.startModelReplication(model, this.storage, replicationConfig);
     return model;
   }
 
+
+  /**
+   * Initialize
+   */
   public init() {
     // Created fixed stores for replication
     // TODO this is just workaround for replication engine

--- a/packages/offix-datastore/src/DataStore.ts
+++ b/packages/offix-datastore/src/DataStore.ts
@@ -64,7 +64,7 @@ export class DataStore {
   public createModel<T>(schema: DataSyncJsonSchema<T>) {
     const modelSchema = new ModelSchema(schema);
     const model = new Model<T>(modelSchema, this.storage);
-    this.replicator?.getModelReplicator(model, this.storage);
+    this.replicator?.startModelReplication(model, this.storage);
     return model;
   }
 

--- a/packages/offix-datastore/src/Model.ts
+++ b/packages/offix-datastore/src/Model.ts
@@ -47,7 +47,6 @@ export interface ModelConfig<T = unknown> {
  */
 export class Model<T = unknown> {
   public schema: ModelSchema<T>;
-  public replicationConfig?: ModelReplicationConfig;
   public replicator?: IModelReplicator;
   private storage: LocalStorage;
   private changeEventStream: PushStream<StoreChangeEvent>;
@@ -137,15 +136,6 @@ export class Model<T = unknown> {
     return this.changeEventStream.subscribe((event: StoreChangeEvent) => {
         listener(event);
       }, (event: StoreChangeEvent) => (event.eventType === eventType));
-  }
-
-  /**
-   * Setup custom overrides for the model replication system
-   *
-   * @param replicationConfig replication configuration for individual model
-   */
-  public setupReplication(replicationConfig: ModelReplicationConfig) {
-    this.replicationConfig = replicationConfig;
   }
 
   /**

--- a/packages/offix-datastore/src/Model.ts
+++ b/packages/offix-datastore/src/Model.ts
@@ -73,7 +73,9 @@ export class Model<T = unknown> {
   }
 
   public save(input: T): Promise<T> {
-    return this.storage.save(this.schema.getStoreName(), input);
+    const data = this.storage.save(this.schema.getStoreName(), input);
+    this.replicator?.replicate(data, CRUDEvents.ADD);
+    return data;
   }
 
   public query(predicateFunction?: Predicate<T>) {
@@ -92,7 +94,9 @@ export class Model<T = unknown> {
 
     const modelPredicate = createPredicate(this.schema.getFields());
     const predicate = predicateFunction(modelPredicate);
-    return this.storage.update(this.schema.getStoreName(), input, predicate);
+    const data = this.storage.update(this.schema.getStoreName(), input, predicate);
+    this.replicator?.replicate(data, CRUDEvents.UPDATE);
+    return data;
   }
 
   public remove(predicateFunction?: Predicate<T>) {
@@ -103,7 +107,9 @@ export class Model<T = unknown> {
 
     const modelPredicate = createPredicate(this.schema.getFields());
     const predicate = predicateFunction(modelPredicate);
-    return this.storage.remove(this.schema.getStoreName(), predicate);
+    const data = this.storage.remove(this.schema.getStoreName(), predicate);
+    this.replicator?.replicate(data, CRUDEvents.DELETE);
+    return data;
   }
 
   public subscribe(eventType: CRUDEvents, listener: (event: StoreChangeEvent) => void) {

--- a/packages/offix-datastore/src/replication/GraphQLReplicator.ts
+++ b/packages/offix-datastore/src/replication/GraphQLReplicator.ts
@@ -7,6 +7,7 @@ import { NetworkStatus } from "../network/NetworkStatus";
 import { GlobalReplicationConfig, ModelReplicationConfig } from "./api/ReplicationConfig";
 import { createGraphQLClient } from "./utils/createGraphQLClient";
 import { ModelReplication } from "./ModelReplication";
+import { Client } from "urql";
 
 /**
  * Defaults for replicating settings aggregated in single place
@@ -34,35 +35,26 @@ export const defaultConfig: GlobalReplicationConfig = {
  * Performs replication using GraphQL
  */
 export class GraphQLCRUDReplicator implements IReplicator {
+  private client: Client;
   private config: GlobalReplicationConfig;
   private networkStatus: NetworkStatus;
 
   constructor(globalReplicationConfig: GlobalReplicationConfig) {
     this.config = Object.assign({}, defaultConfig, globalReplicationConfig);
     this.networkStatus = this.config.networkStatus || new WebNetworkStatus();
+    this.client = createGraphQLClient(this.config.client);
   }
 
-  /**
-   * Starts replication by initializing client and create replication engines for each model
-   *
-   * @param models
-   * @param storage
-   */
-  public async start(models: Model[], storage: LocalStorage) {
-    // Generic client created only once at startup
-    const client = createGraphQLClient(this.config.client);
-    for (const model of models) {
-      let config: ModelReplicationConfig = this.config;
-      if (model.replicationConfig) {
-        config = Object.assign({}, this.config, model.replicationConfig);
-      }
-
-      // Replication on model level gives more refined control how individual
-      // models are replicate and allows developers to directly control it.
-      const modelReplication = new ModelReplication(model, storage, client);
-      modelReplication.init(config, this.networkStatus);
-      // We need to inject replicator for users to be able to execute it's public method
-      model.setReplicator(modelReplication);
+  public getModelReplicator(model: Model, storage: LocalStorage) {
+    let config: ModelReplicationConfig = this.config;
+    if (model.replicationConfig) {
+      config = Object.assign({}, this.config, model.replicationConfig);
     }
+
+    // Replication on model level gives more refined control how individual
+    // models are replicate and allows developers to directly control it.
+    const modelReplication = new ModelReplication(model, storage, this.client);
+    modelReplication.init(config, this.networkStatus);
+    model.setReplicator(modelReplication);
   }
 }

--- a/packages/offix-datastore/src/replication/GraphQLReplicator.ts
+++ b/packages/offix-datastore/src/replication/GraphQLReplicator.ts
@@ -45,7 +45,7 @@ export class GraphQLCRUDReplicator implements IReplicator {
     this.client = createGraphQLClient(this.config.client);
   }
 
-  public getModelReplicator(model: Model, storage: LocalStorage) {
+  public startModelReplication(model: Model, storage: LocalStorage) {
     let config: ModelReplicationConfig = this.config;
     if (model.replicationConfig) {
       config = Object.assign({}, this.config, model.replicationConfig);

--- a/packages/offix-datastore/src/replication/GraphQLReplicator.ts
+++ b/packages/offix-datastore/src/replication/GraphQLReplicator.ts
@@ -45,10 +45,10 @@ export class GraphQLCRUDReplicator implements IReplicator {
     this.client = createGraphQLClient(this.config.client);
   }
 
-  public startModelReplication(model: Model, storage: LocalStorage) {
+  public startModelReplication(model: Model, storage: LocalStorage, replicationConfig?: ModelReplicationConfig) {
     let config: ModelReplicationConfig = this.config;
-    if (model.replicationConfig) {
-      config = Object.assign({}, this.config, model.replicationConfig);
+    if (replicationConfig) {
+      config = Object.assign({}, this.config, replicationConfig);
     }
 
     // Replication on model level gives more refined control how individual

--- a/packages/offix-datastore/src/replication/api/Replicator.ts
+++ b/packages/offix-datastore/src/replication/api/Replicator.ts
@@ -32,8 +32,9 @@ export interface IReplicator {
    * Start replication for this model
    * @param model - model used for replication
    * @param storage - local storage
+   * @param replicationConfig - configuration for particular model that will override global config
    */
-  startModelReplication(model: Model, storage: LocalStorage): void;
+  startModelReplication(model: Model, storage: LocalStorage, replicationConfig?: ModelReplicationConfig): void;
 }
 
 /**

--- a/packages/offix-datastore/src/replication/api/Replicator.ts
+++ b/packages/offix-datastore/src/replication/api/Replicator.ts
@@ -29,12 +29,11 @@ export const MODEL_METADATA_KEY = "storeName";
  */
 export interface IReplicator {
   /**
-   * Start replication process for managed models
    *
-   * @param models - models used for replication
+   * @param model - model used for replication
    * @param storage - local storage
    */
-  start(models: Model[], storage: LocalStorage): void;
+  getModelReplicator(model: Model, storage: LocalStorage): void;
 }
 
 /**
@@ -59,4 +58,6 @@ export interface IModelReplicator {
    * Removes all metadata used to replicate model and starts with the new configuration
    */
   resetReplication<T>(config: ModelReplicationConfig): void;
+
+  replicate(data: any, eventType: CRUDEvents): Promise<void>;
 }

--- a/packages/offix-datastore/src/replication/api/Replicator.ts
+++ b/packages/offix-datastore/src/replication/api/Replicator.ts
@@ -29,11 +29,11 @@ export const MODEL_METADATA_KEY = "storeName";
  */
 export interface IReplicator {
   /**
-   *
+   * Start replication for this model
    * @param model - model used for replication
    * @param storage - local storage
    */
-  getModelReplicator(model: Model, storage: LocalStorage): void;
+  startModelReplication(model: Model, storage: LocalStorage): void;
 }
 
 /**

--- a/packages/offix-datastore/src/replication/mutations/MutationsQueue.ts
+++ b/packages/offix-datastore/src/replication/mutations/MutationsQueue.ts
@@ -138,7 +138,7 @@ export class MutationsReplicationQueue {
   }
 
   private saveStore() {
-    this.options.storage.save(MUTATION_QUEUE, { storeName: this.options.model.getStoreName(), items: this.items }, "replication");
+    this.options.storage.save(MUTATION_QUEUE, { storeName: this.options.model.getStoreName(), items: this.items });
   }
 
   private resultProcessor(queue: MutationRequest[], currentItem: MutationRequest, data: OperationResult<any>) {

--- a/packages/offix-datastore/src/replication/mutations/MutationsQueue.ts
+++ b/packages/offix-datastore/src/replication/mutations/MutationsQueue.ts
@@ -84,7 +84,7 @@ export class MutationsReplicationQueue {
     }
     // Clone queue
     let currentItems = Object.assign({}, this.items) as MutationRequest[];
-    while (open && currentItems.length !== 0) {
+    while (this.open && currentItems.length !== 0) {
       const isOnline = await this.options.networkStatus.isOnline();
       if (isOnline) {
         const item = currentItems.shift();

--- a/packages/offix-datastore/tests/Storage.test.ts
+++ b/packages/offix-datastore/tests/Storage.test.ts
@@ -15,17 +15,10 @@ describe("Test Transactions", () => {
     });
 
     afterEach(async () => {
-        storage.storeChangeEventStream.finishSubscriptions();
         await storage.remove(storeName);
     });
 
     test("transaction commit", async () => {
-        expect.assertions(2);
-
-        storage.storeChangeEventStream.subscribe(event => {
-            expect(event.data).toHaveProperty("name", "test");
-        });
-
         const transaction = await storage.createTransaction();
         await transaction.save(storeName, { name: "test" });
         await transaction.commit();
@@ -35,10 +28,6 @@ describe("Test Transactions", () => {
     });
 
     test("transaction rollback", async () => {
-        storage.storeChangeEventStream.subscribe(() => {
-            fail("No event should be fired");
-        });
-
         const transaction = await storage.createTransaction();
         await transaction.save(storeName, { name: "test 1" });
         await transaction.save(storeName, { name: "test 2" });

--- a/packages/offix-datasync-codegen/src/OffixDataSyncPlugin.ts
+++ b/packages/offix-datasync-codegen/src/OffixDataSyncPlugin.ts
@@ -72,7 +72,7 @@ export const schema = jsonSchema as Schema;
             .filter(model => isDataSyncClientModel(model))
             .forEach((model) => {
                 const name = model.graphqlType.name;
-                modelInitLines.push(`export const ${name}Model = datastore.createModel(schema.${name});`);
+                modelInitLines.push(`export const ${name}Model = datastore.setupModel(schema.${name});`);
             });
 
         const configCode = `import { DataStore } from 'offix-datastore';

--- a/packages/offix-datasync-codegen/tests/__snapshots__/DataSyncClientPlugin.test.ts.snap
+++ b/packages/offix-datasync-codegen/tests/__snapshots__/DataSyncClientPlugin.test.ts.snap
@@ -12,8 +12,8 @@ export const datastore = new DataStore({
     }
 });
 
-export const NoteModel = datastore.createModel(schema.Note);
-export const CommentModel = datastore.createModel(schema.Comment);
+export const NoteModel = datastore.setupModel(schema.Note);
+export const CommentModel = datastore.setupModel(schema.Comment);
 
 datastore.init();
 "


### PR DESCRIPTION
### Description

In this PR, I have moved events to Model. We need to implement update strategies so replication is no longer event-based. Now we can fire events after replication or before replication. We need to rethink the information in change events since replication no longer uses events. I didn't change the code too much, there are still lots of improvements we can make now that replication is called in Model.