### PR TITLE
Quick fixes and IDB Cursor Support

### DIFF
--- a/packages/datastore/datastore/package.json
+++ b/packages/datastore/datastore/package.json
@@ -41,6 +41,7 @@
     "fake-indexeddb": "3.1.2",
     "isomorphic-unfetch": "3.0.0",
     "jest": "26.3.0",
+    "react": "^16.13.1",
     "size-limit": "4.5.6",
     "supports-color": "7.1.0",
     "ts-jest": "26.2.0",

--- a/packages/datastore/datastore/package.json
+++ b/packages/datastore/datastore/package.json
@@ -21,7 +21,7 @@
     "size:why": "size-limit --why"
   },
   "peerDependencies": {
-    "react": "16.13.1"
+    "react": "^16.3.1"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -32,17 +32,15 @@
     "@size-limit/preset-small-lib": "4.5.6",
     "@types/jest": "25.2.3",
     "@types/json-schema": "7.0.5",
-    "@types/uuid": "8.3.0",
     "@types/react-dom": "16.9.8",
     "@types/traverse": "0.6.32",
+    "@types/uuid": "8.3.0",
     "@types/websql": "0.0.27",
     "apollo-server": "2.16.1",
     "debug": "4.1.1",
     "fake-indexeddb": "3.1.2",
     "isomorphic-unfetch": "3.0.0",
     "jest": "26.3.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
     "size-limit": "4.5.6",
     "supports-color": "7.1.0",
     "ts-jest": "26.2.0",
@@ -52,8 +50,8 @@
     "graphql-tag": "2.11.0",
     "subscriptions-transport-ws": "0.9.17",
     "tiny-invariant": "1.1.0",
-    "urql": "1.10.0",
     "traverse": "0.6.6",
+    "urql": "1.10.0",
     "uuid": "8.3.0",
     "websql": "1.0.0",
     "wonka": "4.0.14",

--- a/packages/datastore/datastore/src/react/hooks/query.ts
+++ b/packages/datastore/datastore/src/react/hooks/query.ts
@@ -9,6 +9,10 @@ const createSubscribeToMore = (model: Model, dispatch: Dispatch<Action>) => {
         // TODO subscribe to specific predicate
         const subscription = model.subscribe(eventType, (event) => {
             const newData = updateResult(event.data);
+            if (subscription.closed) {
+                // Important to check beacuse Componnent could be unmounted
+                return;
+            }
             dispatch({ type: ActionType.UPDATE_RESULT, data: newData });
         });
         return subscription;

--- a/packages/datastore/datastore/src/storage/adapters/indexedDB/IndexedDBStorageAdapter.ts
+++ b/packages/datastore/datastore/src/storage/adapters/indexedDB/IndexedDBStorageAdapter.ts
@@ -3,7 +3,7 @@ import { generateId } from "../../LocalStorage";
 import { createLogger } from "../../../utils/logger";
 import { ModelSchema } from "../../../ModelSchema";
 import { Filter } from "../../../filters";
-import { createPredicateFrom, getPredicate } from "./Predicate";
+import { getPredicate } from "./Predicate";
 
 const logger = createLogger("idb");
 
@@ -39,7 +39,7 @@ export class IndexedDBStorageAdapter implements StorageAdapter {
     openreq.onerror = () => this.rejectIDB(openreq.error);
     openreq.onsuccess = () => {
       const db = openreq.result;
-      db.onversionchange = function () {
+      db.onversionchange = function() {
         // FIXME critical to handle version changes
         this.close();
       };
@@ -136,7 +136,7 @@ export class IndexedDBStorageAdapter implements StorageAdapter {
         } else {
           resolve(result);
         }
-      }
+      };
 
       cursorReq.onerror = () => reject(cursorReq.error);
     });

--- a/packages/datastore/datastore/src/storage/adapters/indexedDB/Predicate.ts
+++ b/packages/datastore/datastore/src/storage/adapters/indexedDB/Predicate.ts
@@ -1,23 +1,6 @@
 import { ANDNode } from "./Nodes";
 import { createNodes } from "./createNodes";
 
-export class Predicate {
-    private root: ANDNode;
-
-    constructor(root: ANDNode) {
-        this.root = root;
-    }
-
-    public filter(data: any[]) {
-        return data.filter((val) => this.root.isPassed(val));
-    }
-}
-
-export const createPredicateFrom = (filter: any) => {
-    const nodes = createNodes(filter);
-    return new Predicate(new ANDNode(nodes));
-};
-
 export const getPredicate = (filter: any) => {
     const nodes = createNodes(filter);
     const root = new ANDNode(nodes);

--- a/packages/datastore/datastore/src/storage/adapters/indexedDB/Predicate.ts
+++ b/packages/datastore/datastore/src/storage/adapters/indexedDB/Predicate.ts
@@ -17,3 +17,9 @@ export const createPredicateFrom = (filter: any) => {
     const nodes = createNodes(filter);
     return new Predicate(new ANDNode(nodes));
 };
+
+export const getPredicate = (filter: any) => {
+    const nodes = createNodes(filter);
+    const root = new ANDNode(nodes);
+    return (data: any) => (root.isPassed(data));
+};

--- a/packages/datastore/datastore/src/storage/adapters/websql/filterToSQL.ts
+++ b/packages/datastore/datastore/src/storage/adapters/websql/filterToSQL.ts
@@ -66,5 +66,5 @@ const extractExpression = (filter: any, separator: "AND" | "OR" = "AND"): string
 
 export const filterToSQL = (filter?: Filter) => {
     if (!filter) { return ""; };
-    return `WHERE ${extractExpression(filter)} ?`;
+    return `WHERE ${extractExpression(filter)}`;
 };

--- a/packages/datastore/datastore/src/storage/adapters/websql/utils.ts
+++ b/packages/datastore/datastore/src/storage/adapters/websql/utils.ts
@@ -1,10 +1,8 @@
 import invariant from "tiny-invariant";
-import { generateId } from "../..";
 
 // TODO change to constants/enums
 export const prepareStatement = (input: any, type: string = "insert"): [string, any[]] => {
     if (type === "insert") {
-        input.id = generateId();
         const cols = Object.keys(input).join(",");
         const bindings = Object.keys(input).map(() => "?").join(",");
         const vals = Object.values(input);

--- a/packages/datastore/datastore/src/utils/PushStream.ts
+++ b/packages/datastore/datastore/src/utils/PushStream.ts
@@ -1,6 +1,7 @@
 import Observable from "zen-observable";
 
 export interface Subscription {
+  closed: boolean;
   unsubscribe(): void;
 }
 

--- a/packages/datastore/datastore/tests/Filters.test.ts
+++ b/packages/datastore/datastore/tests/Filters.test.ts
@@ -1,4 +1,4 @@
-import { createPredicateFrom } from '../src/storage/adapters/indexedDB/Predicate';
+import { getPredicate } from '../src/storage/adapters/indexedDB/Predicate';
 import { filterToSQL } from '../src/storage/adapters/websql/filterToSQL';
 import { WebSQLAdapter, LocalStorage, ModelSchema } from '../src';
 
@@ -14,8 +14,8 @@ describe("Test IndexedDB filters", () => {
         const list = [
             { clickCount: 9 }, { clickCount: 4 }
         ];
-        const predicate = createPredicateFrom({ clickCount: { lt: 9, ne: 4 } });
-        const result = predicate.filter(list);
+        const predicate = getPredicate({ clickCount: { lt: 9, ne: 4 } });
+        const result = list.filter(predicate);
         expect(result.length).toEqual(0);
     });
 
@@ -23,8 +23,8 @@ describe("Test IndexedDB filters", () => {
         const list = [
             { clickCount: 9 }, { clickCount: 4 }
         ];
-        const predicate = createPredicateFrom({ clickCount: 9 });
-        const result = predicate.filter(list);
+        const predicate = getPredicate({ clickCount: 9 });
+        const result = list.filter(predicate);
         expect(result).toEqual([list[0]]);
     });
 
@@ -34,7 +34,7 @@ describe("Test IndexedDB filters", () => {
             { clickCount: 4, isTest: false },
             { clickCount: 4, isTest: true }
         ];
-        const predicate = createPredicateFrom({
+        const predicate = getPredicate({
             or: {
                 clickCount: { eq: 9 },
                 not: {
@@ -43,7 +43,7 @@ describe("Test IndexedDB filters", () => {
             }
         });
 
-        const result = predicate.filter(list);
+        const result = list.filter(predicate);
         expect(result).toEqual([list[0], list[2]]);
     });
 });

--- a/packages/datastore/datastore/tests/Filters.test.ts
+++ b/packages/datastore/datastore/tests/Filters.test.ts
@@ -54,11 +54,11 @@ describe("Test SQL filters", () => {
             clickCount: { eq: 5 },
             title: { eq: 'Test' }
         };
-        let expectedSQL = "WHERE (clickCount = 5 AND title = 'Test') ?";
+        let expectedSQL = "WHERE (clickCount = 5 AND title = 'Test')";
         let actualSQL = filterToSQL(filter);
         expect(actualSQL).toEqual(expectedSQL);
 
-        expectedSQL = "WHERE (title LIKE 'Test%') ?";
+        expectedSQL = "WHERE (title LIKE 'Test%')";
         actualSQL = filterToSQL({ title: { startsWith: 'Test' } });
         expect(actualSQL).toEqual(expectedSQL);
     });
@@ -68,7 +68,7 @@ describe("Test SQL filters", () => {
             clickCount: 5,
             title: 'Test'
         };
-        const expectedSQL = "WHERE (clickCount = 5 AND title = 'Test') ?";
+        const expectedSQL = "WHERE (clickCount = 5 AND title = 'Test')";
         const actualSQL = filterToSQL(filter);
         expect(actualSQL).toEqual(expectedSQL);
     });
@@ -80,7 +80,7 @@ describe("Test SQL filters", () => {
                 ne: 15
             },
         };
-        const expectedSQL = "WHERE (clickCount > 9 AND clickCount != 15) ?";
+        const expectedSQL = "WHERE (clickCount > 9 AND clickCount != 15)";
         const actualSQL = filterToSQL(filter);
         expect(actualSQL).toEqual(expectedSQL);
     });
@@ -96,7 +96,7 @@ describe("Test SQL filters", () => {
             }
         };
 
-        const expectedSQL = "WHERE ((title = 'Fun' OR NOT (clickCount = 5 AND title = 'Test'))) ?";
+        const expectedSQL = "WHERE ((title = 'Fun' OR NOT (clickCount = 5 AND title = 'Test')))";
         const actualSQL = filterToSQL(filter);
         expect(actualSQL).toEqual(expectedSQL);
     });


### PR DESCRIPTION
### Description

I modified the sample app to handle change events. I also tried to verify that the `contains` op works when using websql. It works for strings but not for arrays (I created test cases for both). I created an issue detailing the problem with arrays on websql #712. Getting the sample to work with the linked package was tricky but you can run it if you go into `offix/node_modules` and delete the react folder. Note that "react" will be re-installed the next time you run `yarn install` inside the workspace whether there's a react dependency in datastore or not because "react-offix-hooks" depends on it too. I also removed the react dependency but had to add it again because "urql" requires it and the tests won't run. Other small fixes are also in this PR.

#### EDIT

I have added cursor support for IDBAdapter to this PR

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
