### PR TITLE
Query, Update and Delete by ID

### DIFF
--- a/packages/datastore/datastore/src/storage/LocalStorage.ts
+++ b/packages/datastore/datastore/src/storage/LocalStorage.ts
@@ -58,14 +58,26 @@ export class LocalStorage {
     return this.adapter.query(storeName, filter);
   }
 
+  public queryById(storeName: string, id: string) {
+    return this.adapter.queryById(storeName, id);
+  }
+
   public async update(storeName: string, input: any, filter?: Filter): Promise<any> {
     const result = await this.adapter.update(storeName, input, filter);
     return result;
   }
 
+  public updateById(storeName: string, input: any, id: string) {
+    return this.adapter.updateById(storeName, input, id);
+  }
+
   public async remove(storeName: string, filter?: Filter): Promise<any | any[]> {
     const result = await this.adapter.remove(storeName, filter);
     return result;
+  }
+
+  public removeById(storeName: string, id: string) {
+    return this.adapter.removeById(storeName, id);
   }
 
   /**

--- a/packages/datastore/datastore/src/storage/adapters/indexedDB/IndexedDBStorageAdapter.ts
+++ b/packages/datastore/datastore/src/storage/adapters/indexedDB/IndexedDBStorageAdapter.ts
@@ -13,14 +13,14 @@ const logger = createLogger("idb");
  */
 export class IndexedDBStorageAdapter implements StorageAdapter {
   private indexedDB: Promise<IDBDatabase>;
-  private stores: ModelSchema[] = [];
+  private stores: ModelSchema[];
   private resolveIDB: any;
   private rejectIDB: any;
   private transaction?: IDBTransaction;
   private dbName: string;
   private schemaVersion: number;
 
-  constructor(dbName: string, schemaVersion: number, transaction?: IDBTransaction) {
+  constructor(dbName: string, schemaVersion: number, transaction?: IDBTransaction, stores: ModelSchema[] = []) {
     this.dbName = dbName;
     this.schemaVersion = schemaVersion;
     this.indexedDB = new Promise((resolve, reject) => {
@@ -28,6 +28,7 @@ export class IndexedDBStorageAdapter implements StorageAdapter {
       this.rejectIDB = reject;
     });
     this.transaction = transaction;
+    this.stores = stores;
   }
   // TODO Wrong architecture. Store can be created on demand
   public addStore(config: ModelSchema) {
@@ -76,7 +77,7 @@ export class IndexedDBStorageAdapter implements StorageAdapter {
   public async createTransaction() {
     const db = await this.indexedDB;
     const transaction = db.transaction((db.objectStoreNames as unknown as string[]), "readwrite");
-    return new IndexedDBStorageAdapter(this.dbName, this.schemaVersion, transaction);
+    return new IndexedDBStorageAdapter(this.dbName, this.schemaVersion, transaction, this.stores);
   }
 
   public commit() {

--- a/packages/datastore/datastore/src/storage/adapters/utils.ts
+++ b/packages/datastore/datastore/src/storage/adapters/utils.ts
@@ -1,0 +1,7 @@
+import { ModelSchema } from "../../ModelSchema";
+
+export const getPrimaryKey = (schemas: ModelSchema[], storeName: string) => {
+    const schema = schemas.find((s) => (s.getStoreName() === storeName));
+    if (!schema) { throw new Error("Store does not exist"); }
+    return schema.getPrimaryKey();
+};

--- a/packages/datastore/datastore/src/storage/api/StorageAdapter.ts
+++ b/packages/datastore/datastore/src/storage/api/StorageAdapter.ts
@@ -61,6 +61,8 @@ export interface StorageAdapter {
    */
   query(storeName: string, filter?: Filter): Promise<any | any[]>;
 
+  queryById(storeName: string, id: string): Promise<any>;
+
   /**
    * Update data matching predicate or all data if predicate is not specified
    * with input.
@@ -72,6 +74,8 @@ export interface StorageAdapter {
    */
   update(storeName: string, input: any, filter?: Filter): Promise<any[]>;
 
+  updateById(storeName: string, input: any, id: string): Promise<any>;
+
   /**
    * Deletes data matching predicate or all from the store
    *
@@ -80,4 +84,6 @@ export interface StorageAdapter {
    * @returns A Promise of the deleted data
    */
   remove(storeName: string, filter?: Filter): Promise<any[]>;
+
+  removeById(storeName: string, id: string): Promise<any>;
 }

--- a/packages/datastore/datastore/src/storage/api/StorageAdapter.ts
+++ b/packages/datastore/datastore/src/storage/api/StorageAdapter.ts
@@ -52,11 +52,11 @@ export interface StorageAdapter {
   save(storeName: string, input: any): Promise<any>;
 
   /**
-   * Queries data from the store matching the predicate.
-   * Returns all the data if predicate is not specified
+   * Queries data from the store matching the filter.
+   * Returns all the data if filter is not specified
    *
    * @param storeName The name of the store
-   * @param predicate A PredicateFunction to filter data
+   * @param fliter
    * @returns A Promise of the query results
    */
   query(storeName: string, filter?: Filter): Promise<any | any[]>;
@@ -64,12 +64,12 @@ export interface StorageAdapter {
   queryById(storeName: string, id: string): Promise<any>;
 
   /**
-   * Update data matching predicate or all data if predicate is not specified
+   * Update data matching filter or all data if filter is not specified
    * with input.
    *
    * @param storeName The name of the store
    * @param input The update to be made
-   * @param predicate A PredicateFunction to filter data
+   * @param filter
    * @returns A Promise of the updated data
    */
   update(storeName: string, input: any, filter?: Filter): Promise<any[]>;
@@ -77,10 +77,10 @@ export interface StorageAdapter {
   updateById(storeName: string, input: any, id: string): Promise<any>;
 
   /**
-   * Deletes data matching predicate or all from the store
+   * Deletes data matching filter or all from the store
    *
    * @param storeName The name of the store
-   * @param predicate A PredicateFunction to filter data
+   * @param filter
    * @returns A Promise of the deleted data
    */
   remove(storeName: string, filter?: Filter): Promise<any[]>;

--- a/packages/datastore/datastore/tests/DataStore.test.ts
+++ b/packages/datastore/datastore/tests/DataStore.test.ts
@@ -30,13 +30,13 @@ function getIndexedDB() {
 }
 
 interface Note {
-  id?: string;
+  id: string;
   title: string;
   description: string;
 }
 
 interface Comment {
-  id?: string;
+  id: string;
   title: string;
   noteId: string;
 }
@@ -96,31 +96,26 @@ test("Save Note to local store", async () => {
 test("Query from local store", async () => {
   const note = { title: "test", description: "description" };
   const savedNote = await NoteModel.save(note);
-  const results = (await NoteModel.query({ title: note.title }));
-  expect(results[0]).toHaveProperty("id", savedNote.id);
+  const result = await NoteModel.queryById(savedNote.id);
+  expect(result).toHaveProperty("id", savedNote.id);
 });
 
-test("Update single entity in local store", async () => {
+test.only("Update single entity in local store", async () => {
   const note = { title: "test", description: "description" };
   const savedNote = await NoteModel.save(note);
   const newTitle = "updated note";
 
-  await NoteModel.update({
-    ...savedNote,
-    title: newTitle
-  }, { id: savedNote.id });
-
-  const updatedNote = (await NoteModel.query({ id: savedNote.id }))[0];
-
+  await NoteModel.updateById({ title: newTitle }, savedNote.id);
+  const updatedNote = await NoteModel.queryById(savedNote.id);
   expect(updatedNote.title).toEqual(newTitle);
 });
 
 test("Remove single entity from local store", async () => {
   const note = { title: "test", description: "description" };
   const savedNote = await NoteModel.save(note);
-  await NoteModel.remove({ id: savedNote.id });
-  const results = (await NoteModel.query({ id: savedNote.id }));
-  expect(results.length).toEqual(0);
+  await NoteModel.removeById(savedNote.id);
+  const result = await NoteModel.queryById(savedNote.id);
+  expect(result).toEqual(undefined);
 });
 
 test("Remove all entities matching predicate from local store", async () => {

--- a/packages/datastore/datastore/tests/DataStore.test.ts
+++ b/packages/datastore/datastore/tests/DataStore.test.ts
@@ -35,12 +35,6 @@ interface Note {
   description: string;
 }
 
-interface Comment {
-  id: string;
-  title: string;
-  noteId: string;
-}
-
 let NoteModel: Model<Note>;
 
 beforeEach(() => {
@@ -51,11 +45,6 @@ beforeEach(() => {
     name: "Note",
     type: "object",
     properties: schema.Note
-  });
-  dataStore.setupModel<Comment>({
-    name: "Comment",
-    type: "object",
-    properties: schema.Comment
   });
   dataStore.init();
 });
@@ -71,7 +60,6 @@ afterEach(async () => {
 test("Setup client db with provided models", async () => {
   const db = await getIndexedDB();
   expect(db.objectStoreNames).toContain("user_Note");
-  expect(db.objectStoreNames).toContain("user_Comment");
   db.close();
 });
 
@@ -100,7 +88,7 @@ test("Query from local store", async () => {
   expect(result).toHaveProperty("id", savedNote.id);
 });
 
-test.only("Update single entity in local store", async () => {
+test("Update single entity in local store", async () => {
   const note = { title: "test", description: "description" };
   const savedNote = await NoteModel.save(note);
   const newTitle = "updated note";


### PR DESCRIPTION
### Description

Implementation of Query, Update and Delete by ID. Here, I added three new methods to our API that performs, query, update and delete operations using the ID. Although the methods have "ById" in their names, I do not use "Hardcoded id", I obtain the primary key from the store schema and use it for the operations. It might be better for us to by Primary Key(like updateByPrimaryKey) instead since we are not actually using "id". 

##### Checklist

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
