### PR TITLE
New subscribe to more api

### DIFF
--- a/docs/datastore/react.md
+++ b/docs/datastore/react.md
@@ -79,15 +79,19 @@ const documentId = "";
 const { isLoading, error, data: tasks } = useQuery(TaskModel, documentId);
 ```
 
-You can also subscribe to more changes using the `subscribeToMore` function
+You can also subscribe to changes using the `subscribeToMore` function.
 
 ```javascript
 const { isLoading, error, data: tasks, subscribeToMore } = useQuery(TaskModel, filter);
 useEffect(() => {
-    const subscription = subscribeToMore([CRUDEvents.ADD, CRUDEvents.UPDATE, CRUDEvents.DELETE]);
+    const subscription = subscribeToMore();
     return () => subscription.unsubscribe();
 }, []);
 ```
+
+`subscribeToMore` can take an array of events to watch
+
+`const subscription = subscribeToMore([CRUDEvents.ADD, CRUDEvents.UPDATE]);`
 
 Offix Datastore reponds to events and updates your Application state for you. You can also override
 Datastore's event handlers.
@@ -208,3 +212,7 @@ const Task = ({ task }) => {
     return <div>{task.title}</div>
 }
 ```
+
+We can listen to a events on all documents
+
+`const { data } = useSubscription(TaskModel, [CRUDEvents.UPDATE]);`

--- a/docs/datastore/react.md
+++ b/docs/datastore/react.md
@@ -205,14 +205,14 @@ by `useSubscription` is the data carried by the change event.
 
 ```javascript
 const Task = ({ task }) => {
-    // Listen for updates on this task
-    const { data } = useSubscription(TaskModel, [CRUDEvents.UPDATE], task);
-    task = data[0] || task; // data is undefined when no events have been fired
+    const { data } = useSubscription(TaskModel, [CRUDEvents.UPDATE]);
+    // data is undefined when no events have been fired
+    const task = data ? data.find((d) => (d._id === task._id)) : task;
 
     return <div>{task.title}</div>
 }
 ```
 
-We can listen to a events on all documents
+We can listen to all events on all documents
 
-`const { data } = useSubscription(TaskModel, [CRUDEvents.UPDATE]);`
+`const { data } = useSubscription(TaskModel);`

--- a/docs/datastore/react.md
+++ b/docs/datastore/react.md
@@ -84,7 +84,18 @@ You can also subscribe to more changes using the `subscribeToMore` function
 ```javascript
 const { isLoading, error, data: tasks, subscribeToMore } = useQuery(TaskModel, filter);
 useEffect(() => {
-    const subscription = subscribeToMore(CRUDEvents.ADD, (newData) => {
+    const subscription = subscribeToMore([CRUDEvents.ADD, CRUDEvents.UPDATE, CRUDEvents.DELETE]);
+    return () => subscription.unsubscribe();
+}, []);
+```
+
+Offix Datastore reponds to events and updates your Application state for you. You can also override
+Datastore's event handlers.
+
+```javascript
+const { isLoading, error, data: tasks, subscribeToMore } = useQuery(TaskModel, filter);
+useEffect(() => {
+    const subscription = subscribeToMore([CRUDEvents.ADD], (newData) => {
         if (!tasks) return [newData];
         return [...tasks, newData];
     });
@@ -115,8 +126,8 @@ const Tasks = () => {
 }
 ```
 
-The `query` function also returns a `subscribeToMore` function
-that you can use to subscribe to changes for that query. 
+The `useLazyQuery` hook also provides a `subscribeToMore` function
+that you can use to subscribe to events on your data.
 
 ## useUpdate
 
@@ -184,14 +195,14 @@ const Task = ({ task }) => {
 
 ## useSubscription
 
-You can subscribe to specific events and receive changes data using this hook.
+You can subscribe to multiple events and receive changes data using this hook.
 We listen for updates to the task and render them. The `data` returned
 by `useSubscription` is the data carried by the change event.
 
 ```javascript
 const Task = ({ task }) => {
     // Listen for updates on this task
-    const { data } = useSubscription(TaskModel, CRUDEvents.UPDATE, task);
+    const { data } = useSubscription(TaskModel, [CRUDEvents.UPDATE], task);
     task = data[0] || task; // data is undefined when no events have been fired
 
     return <div>{task.title}</div>

--- a/docs/datastore/subscriptions.md
+++ b/docs/datastore/subscriptions.md
@@ -14,10 +14,22 @@ The change events that can occur are;
 - `UPDATE` data is updated in the Store. The event payload is the updated data
 - `DELETE` data is removed from the Store. The event payload is the removed data
 
+You can subscribe to all change events on a Model.
+
 ```typescript
 import { CRUDEvents } from 'offix-datastore';
 
-TaskModel.on([CRUDEvents.ADD], (event) => {
+TaskModel.on((event) => {
     console.dir(event); // { eventType, data }
 });
+```
+
+You can also subscribe to specific events
+
+```typescript
+import { CRUDEvents } from 'offix-datastore';
+
+TaskModel.on((event) => {
+    console.dir(event); // { eventType, data }
+}, [CRUDEvents.ADD]);
 ```

--- a/docs/datastore/subscriptions.md
+++ b/docs/datastore/subscriptions.md
@@ -17,7 +17,7 @@ The change events that can occur are;
 ```typescript
 import { CRUDEvents } from 'offix-datastore';
 
-TaskModel.on(CRUDEvents.ADD, (event) => {
+TaskModel.on([CRUDEvents.ADD], (event) => {
     console.dir(event); // { eventType, data }
 });
 ```

--- a/examples/react-datastore/src/App.tsx
+++ b/examples/react-datastore/src/App.tsx
@@ -6,40 +6,13 @@ import 'antd/dist/antd.css';
 import { useFindTodos } from './datastore/hooks';
 import { TodoList, AddTodo, Loading, Error, Header } from './components';
 
-const onTodoAdded = (currentData: any[], newData: any[]) => {
-  if (!currentData) return newData;
-  return [...currentData, ...newData];
-}
-
-const onTodoChanged = (currentData: any[], newData: any[]) => {
-  if (!currentData) return [];
-
-  return currentData.map((d) => {
-    const index = newData.findIndex((newD) => newD._id === d._id);
-    if (index === -1) return d;
-    return newData[index];
-  });
-}
-
-const onTodoRemoved = (currentData: any[], removedData: any[]) => {
-  if (!currentData) return [];
-  return currentData
-    .filter(
-      (d) => removedData.findIndex((newD) => newD._id === d._id)
-    );
-}
-
 function App() {
 
   const [addView, setAddView] = useState<boolean>(false);
   const  { isLoading: loading, error, data, subscribeToMore } = useFindTodos();
   useEffect(() => {
-    const subscriptions = [
-      subscribeToMore(CRUDEvents.ADD, (newData) => onTodoAdded(data, newData)),
-      subscribeToMore(CRUDEvents.UPDATE, (newData) => onTodoChanged(data, newData)),
-      subscribeToMore(CRUDEvents.DELETE, (newData) => onTodoRemoved(data, newData)),
-    ];
-    return () => subscriptions.forEach(s => s.unsubscribe());
+    const subscription = subscribeToMore([CRUDEvents.ADD, CRUDEvents.UPDATE, CRUDEvents.DELETE]);
+    return () => subscription.unsubscribe();
   }, [data, subscribeToMore]);
 
   if (loading) return <Loading />;

--- a/examples/react-datastore/src/App.tsx
+++ b/examples/react-datastore/src/App.tsx
@@ -11,7 +11,7 @@ function App() {
   const [addView, setAddView] = useState<boolean>(false);
   const  { isLoading: loading, error, data, subscribeToMore } = useFindTodos();
   useEffect(() => {
-    const subscription = subscribeToMore([CRUDEvents.ADD, CRUDEvents.UPDATE, CRUDEvents.DELETE]);
+    const subscription = subscribeToMore();
     return () => subscription.unsubscribe();
   }, [data, subscribeToMore]);
 

--- a/packages/datastore/datastore/package.json
+++ b/packages/datastore/datastore/package.json
@@ -56,6 +56,6 @@
     "uuid": "8.3.0",
     "websql": "1.0.0",
     "wonka": "4.0.14",
-    "zen-observable": "0.8.15"
+    "zen-observable": "^0.8.15"
   }
 }

--- a/packages/datastore/datastore/src/Model.ts
+++ b/packages/datastore/datastore/src/Model.ts
@@ -252,12 +252,12 @@ export class Model<T = unknown> {
    * @param eventType - allows you to specify what event type you are interested in.
    * @param listener
    */
-  public subscribe(listener: (event: StoreChangeEvent) => void, eventType?: CRUDEvents) {
+  public subscribe(listener: (event: StoreChangeEvent) => void, eventTypes?: CRUDEvents[]) {
     return this.changeEventStream.subscribe((event: StoreChangeEvent) => {
       listener(event);
     }, (event: StoreChangeEvent) => {
-      if (eventType) {
-        return event.eventType === eventType;
+      if (eventTypes) {
+        return eventTypes.includes(event.eventType);
       }
       return true;
     });

--- a/packages/datastore/datastore/src/Model.ts
+++ b/packages/datastore/datastore/src/Model.ts
@@ -86,6 +86,10 @@ export class Model<T = unknown> {
     return this.schema.getStoreName();
   }
 
+  public getSchema() {
+    return this.schema;
+  }
+
   public query(filter?: Filter<T>) {
     if (!filter) { return this.storage.query(this.schema.getStoreName()); }
 

--- a/packages/datastore/datastore/src/react/hooks/query.ts
+++ b/packages/datastore/datastore/src/react/hooks/query.ts
@@ -9,34 +9,34 @@ const onAdded = (currentData: any[], newData: any[]) => {
     return [...currentData, ...newData];
 };
 
-const onChanged = (currentData: any[], newData: any[]) => {
+const onChanged = (currentData: any[], newData: any[], primaryKey: string) => {
     if (!currentData) {return [];}
 
     return currentData.map((d) => {
-        const index = newData.findIndex((newD) => newD._id === d._id);
+        const index = newData.findIndex((newD) => newD[primaryKey] === d[primaryKey]);
         if (index === -1) {return d;}
         return newData[index];
     });
 };
 
-const onRemoved = (currentData: any[], removedData: any[]) => {
+const onRemoved = (currentData: any[], removedData: any[], primaryKey: string) => {
     if (!currentData) {return [];}
     return currentData
         .filter(
-            (d) => removedData.findIndex((newD) => newD._id === d._id)
+            (d) => removedData.findIndex((newD) => newD[primaryKey] === d[primaryKey])
         );
 };
 
-const updateResult = (state: ResultState, event: StoreChangeEvent) => {
+export const updateResult = (state: ResultState, event: StoreChangeEvent, primaryKey: string) => {
     switch (event.eventType) {
         case CRUDEvents.ADD:
             return onAdded(state.data, event.data);
 
         case CRUDEvents.UPDATE:
-            return onChanged(state.data, event.data);
+            return onChanged(state.data, event.data, primaryKey);
 
         case CRUDEvents.DELETE:
-            return onRemoved(state.data, event.data);
+            return onRemoved(state.data, event.data, primaryKey);
 
         default:
             throw new Error(`Invalid event ${event.eventType} received`);
@@ -52,7 +52,7 @@ const createSubscribeToMore = (state: ResultState, model: Model, dispatch: Dispa
             if (customEventHandler) {
                 newData = customEventHandler(state, event.data);
             }
-            newData = updateResult(state, event);
+            newData = updateResult(state, event, model.getSchema().getPrimaryKey());
 
             if (!subscription.closed) {
                 // Important to check beacuse Componnent could be unmounted

--- a/packages/datastore/datastore/src/react/hooks/query.ts
+++ b/packages/datastore/datastore/src/react/hooks/query.ts
@@ -44,7 +44,7 @@ export const updateResult = (state: ResultState, event: StoreChangeEvent, primar
 };
 
 const createSubscribeToMore = (state: ResultState, model: Model, dispatch: Dispatch<Action>) => {
-    return (eventsToWatch: CRUDEvents[], customEventHandler?: (state: ResultState, data: any) => any) => {
+    return (eventsToWatch?: CRUDEvents[], customEventHandler?: (state: ResultState, data: any) => any) => {
         // TODO subscribe to specific document
         const subscription = model.subscribe((event) => {
             let newData;

--- a/packages/datastore/datastore/src/react/hooks/query.ts
+++ b/packages/datastore/datastore/src/react/hooks/query.ts
@@ -11,7 +11,7 @@ const onAdded = (currentData: any[], newData: any[]) => {
 
 const onChanged = (currentData: any[], newData: any[], primaryKey: string) => {
     if (!currentData) {return [];}
-
+    // What happens to data that get's updated and falls outside original query filter?
     return currentData.map((d) => {
         const index = newData.findIndex((newD) => newD[primaryKey] === d[primaryKey]);
         if (index === -1) {return d;}
@@ -45,7 +45,6 @@ export const updateResult = (state: ResultState, event: StoreChangeEvent, primar
 
 const createSubscribeToMore = (state: ResultState, model: Model, dispatch: Dispatch<Action>) => {
     return (eventsToWatch?: CRUDEvents[], customEventHandler?: (state: ResultState, data: any) => any) => {
-        // TODO subscribe to specific document
         const subscription = model.subscribe((event) => {
             let newData;
 

--- a/packages/datastore/datastore/src/react/hooks/query.ts
+++ b/packages/datastore/datastore/src/react/hooks/query.ts
@@ -1,27 +1,73 @@
 import { useEffect, useReducer, useCallback, Dispatch } from "react";
 import { Model } from "../../Model";
-import { reducer, InitialState, ActionType, Action } from "../ReducerUtils";
-import { CRUDEvents } from "../../storage";
+import { reducer, InitialState, ActionType, Action, ResultState } from "../ReducerUtils";
+import { CRUDEvents, StoreChangeEvent } from "../../storage";
 import { Filter } from "../../filters";
 
-const createSubscribeToMore = (model: Model, dispatch: Dispatch<Action>) => {
-    return (eventType: CRUDEvents, updateResult: (data: any) => any, filter?: Filter) => {
-        // TODO subscribe to specific predicate
+const onAdded = (currentData: any[], newData: any[]) => {
+    if (!currentData) {return newData;}
+    return [...currentData, ...newData];
+};
+
+const onChanged = (currentData: any[], newData: any[]) => {
+    if (!currentData) {return [];}
+
+    return currentData.map((d) => {
+        const index = newData.findIndex((newD) => newD._id === d._id);
+        if (index === -1) {return d;}
+        return newData[index];
+    });
+};
+
+const onRemoved = (currentData: any[], removedData: any[]) => {
+    if (!currentData) {return [];}
+    return currentData
+        .filter(
+            (d) => removedData.findIndex((newD) => newD._id === d._id)
+        );
+};
+
+const updateResult = (state: ResultState, event: StoreChangeEvent) => {
+    switch (event.eventType) {
+        case CRUDEvents.ADD:
+            return onAdded(state.data, event.data);
+
+        case CRUDEvents.UPDATE:
+            return onChanged(state.data, event.data);
+
+        case CRUDEvents.DELETE:
+            return onRemoved(state.data, event.data);
+
+        default:
+            throw new Error(`Invalid event ${event.eventType} received`);
+    }
+};
+
+const createSubscribeToMore = (state: ResultState, model: Model, dispatch: Dispatch<Action>) => {
+    return (eventsToWatch: CRUDEvents[], customEventHandler?: (state: ResultState, data: any) => any) => {
+        // TODO subscribe to specific document
         const subscription = model.subscribe((event) => {
-            const newData = updateResult(event.data);
-            if (subscription.closed) {
-                // Important to check beacuse Componnent could be unmounted
-                return;
+            let newData;
+
+            if (customEventHandler) {
+                newData = customEventHandler(state, event.data);
             }
-            dispatch({ type: ActionType.UPDATE_RESULT, data: newData });
-        }, eventType);
+            newData = updateResult(state, event);
+
+            if (!subscription.closed) {
+                // Important to check beacuse Componnent could be unmounted
+                dispatch({ type: ActionType.UPDATE_RESULT, data: newData });
+            }
+        }, eventsToWatch);
         return subscription;
     };
 };
 
 export const useQuery = (model: Model, selector?: Filter | string) => {
     const [state, dispatch] = useReducer(reducer, InitialState);
-    const subscribeToMore = useCallback(createSubscribeToMore(model, dispatch), [model, dispatch]);
+    const subscribeToMore = useCallback(
+        createSubscribeToMore(state, model, dispatch), [state, model, dispatch]
+    );
 
     useEffect(() => {
         (async () => {
@@ -46,6 +92,9 @@ export const useQuery = (model: Model, selector?: Filter | string) => {
 
 export const useLazyQuery = (model: Model) => {
     const [state, dispatch] = useReducer(reducer, InitialState);
+    const subscribeToMore = useCallback(
+        createSubscribeToMore(state, model, dispatch), [state, model, dispatch]
+    );
 
     const query = async (selector?: Filter | string) => {
         if (state.isLoading) { return; }
@@ -62,14 +111,7 @@ export const useLazyQuery = (model: Model) => {
         } catch (error) {
             dispatch({ type: ActionType.REQUEST_COMPLETE, error });
         }
-
-        /*
-         * Each time the query func is called, a new subscribeToMore
-         * funtion is created. The user has to manually unsuscribe from previous
-         * subscriptions
-         */
-        return createSubscribeToMore(model, dispatch);
     };
 
-    return { ...state, query };
+    return { ...state, query, subscribeToMore };
 };

--- a/packages/datastore/datastore/src/react/hooks/subscription.ts
+++ b/packages/datastore/datastore/src/react/hooks/subscription.ts
@@ -8,7 +8,7 @@ export const useSubscription = (model: Model, eventTypes: CRUDEvents[], filter?:
   const [state, dispatch] = useReducer(reducer, InitialState);
 
   useEffect(() => {
-    // TODO subcribe using predicate
+    // TODO subcribe using filter
     const subscription = model.subscribe((event) => {
       dispatch({ type: ActionType.REQUEST_COMPLETE, data: event.data });
     }, eventTypes);

--- a/packages/datastore/datastore/src/react/hooks/subscription.ts
+++ b/packages/datastore/datastore/src/react/hooks/subscription.ts
@@ -4,16 +4,16 @@ import { CRUDEvents } from "../..";
 import { InitialState, reducer, ActionType } from "../ReducerUtils";
 import { Filter } from "../../filters";
 
-export const useSubscription = (model: Model, eventType: CRUDEvents, filter?: Filter) => {
+export const useSubscription = (model: Model, eventTypes: CRUDEvents[], filter?: Filter) => {
   const [state, dispatch] = useReducer(reducer, InitialState);
 
   useEffect(() => {
     // TODO subcribe using predicate
     const subscription = model.subscribe((event) => {
       dispatch({ type: ActionType.REQUEST_COMPLETE, data: event.data });
-    }, eventType);
+    }, eventTypes);
     return () => subscription.unsubscribe();
-  }, [model, eventType, filter]);
+  }, [model, eventTypes, filter]);
 
   return state;
 };

--- a/packages/datastore/datastore/src/react/hooks/subscription.ts
+++ b/packages/datastore/datastore/src/react/hooks/subscription.ts
@@ -2,18 +2,16 @@ import { useEffect, useReducer } from "react";
 import { Model } from "../../Model";
 import { CRUDEvents } from "../..";
 import { InitialState, reducer, ActionType } from "../ReducerUtils";
-import { Filter } from "../../filters";
 
-export const useSubscription = (model: Model, eventTypes: CRUDEvents[], filter?: Filter) => {
+export const useSubscription = (model: Model, eventTypes: CRUDEvents[]) => {
   const [state, dispatch] = useReducer(reducer, InitialState);
 
   useEffect(() => {
-    // TODO subcribe using filter
     const subscription = model.subscribe((event) => {
       dispatch({ type: ActionType.REQUEST_COMPLETE, data: event.data });
     }, eventTypes);
     return () => subscription.unsubscribe();
-  }, [model, eventTypes, filter]);
+  }, [model, eventTypes]);
 
   return state;
 };

--- a/packages/datastore/datastore/tests/DataStore.test.ts
+++ b/packages/datastore/datastore/tests/DataStore.test.ts
@@ -138,10 +138,10 @@ test("Observe local store events", async () => {
   NoteModel.subscribe((event) => {
     expect(event.eventType).toEqual(CRUDEvents.ADD);
     expect(event.data[0].title).toEqual(note.title);
-  }, CRUDEvents.ADD);
+  }, [CRUDEvents.ADD]);
   NoteModel.subscribe((event) => {
     expect(event.eventType).toEqual(CRUDEvents.UPDATE);
-  }, CRUDEvents.UPDATE);
+  }, [CRUDEvents.UPDATE]);
 
   await NoteModel.save(note);
   await NoteModel.update({ title: "changed" }, { title: "test" });

--- a/packages/datastore/datastore/tests/React.test.ts
+++ b/packages/datastore/datastore/tests/React.test.ts
@@ -1,0 +1,31 @@
+import { updateResult, CRUDEvents } from "../src";
+
+test("it shoud update result for add", () => {
+    const state: any = {};
+    const event = {
+        eventType: CRUDEvents.ADD, data: [{ title: "Test" }]
+    };
+    const result = updateResult(state, event, "title");
+
+    expect(result).toEqual(event.data);
+});
+
+test("it shoud update result for update", () => {
+    const state: any = { data: [{ title: "Test" }] };
+    const event = {
+        eventType: CRUDEvents.UPDATE, data: [{ title: "Test", pass: true }]
+    };
+    const result = updateResult(state, event, "title");
+
+    expect(result).toEqual(event.data);
+});
+
+test("it shoud update result for delete", () => {
+    const state: any = {};
+    const event = {
+        eventType: CRUDEvents.DELETE, data: [{ title: "Test" }]
+    };
+    const result = updateResult(state, event, "title");
+
+    expect(result).toEqual([]);
+});


### PR DESCRIPTION
### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

Here, I have implemented the new `subscribeToMore` API discussed in #767. I had to expose the Model schema through a `getSchema` method so I could obtain primaryKey for use in state update functions. I also modified `Model.subscribe` to accept an array of events to watch.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
- [x] tested with sample app
