### PR TITLE
fix: Loop on hooks

### DIFF
--- a/packages/datastore/datastore/src/react/hooks/update.ts
+++ b/packages/datastore/datastore/src/react/hooks/update.ts
@@ -7,6 +7,7 @@ export const useUpdate = <T>(model: Model<T>) => {
 
     const update = async (input: any, upsert: boolean = false) => {
         if (state.isLoading) { return; }
+        if (state.data) { return; }
 
         dispatch({ type: ActionType.INITIATE_REQUEST });
         try {


### PR DESCRIPTION
This fixes loop on hook. Hook is called in loop because of data state changes (however strange thing happens when only id is present. This seems to solve issue. There might be more elegant solution though

#875 