### PR TITLE
Apply late binding for model replication (fixes #891)

### DIFF
--- a/packages/datastore/datastore/package.json
+++ b/packages/datastore/datastore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offix-datastore",
-  "version": "0.1.2",
+  "version": "0.3.6",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "repository": {

--- a/packages/datastore/datastore/package.json
+++ b/packages/datastore/datastore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offix-datastore",
-  "version": "0.3.7",
+  "version": "0.3.14",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "repository": {

--- a/packages/datastore/datastore/package.json
+++ b/packages/datastore/datastore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offix-datastore",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "repository": {

--- a/packages/datastore/datastore/src/DataStore.ts
+++ b/packages/datastore/datastore/src/DataStore.ts
@@ -83,8 +83,7 @@ export class DataStore {
 
   public restartReplicator(model: Model, filter: Filter) {
     if (this.replicator) {
-      this.replicator.applyFilter(model, filter);
-      this.replicator.resartReplicators(model);
+      this.replicator.resartReplicators(model, filter);
     }
   }
 }

--- a/packages/datastore/datastore/src/DataStore.ts
+++ b/packages/datastore/datastore/src/DataStore.ts
@@ -83,7 +83,7 @@ export class DataStore {
 
   public restartReplicator(model: Model, filter: Filter) {
     if (this.replicator) {
-      model.applyReplicationFilter(filter);
+      this.replicator.applyFilter(model, filter);
       this.replicator.resartReplicators(model);
     }
   }

--- a/packages/datastore/datastore/src/DataStore.ts
+++ b/packages/datastore/datastore/src/DataStore.ts
@@ -7,6 +7,7 @@ import { DataStoreConfig } from "./DataStoreConfig";
 import { createLogger, enableLogger } from "./utils/logger";
 import { ModelReplicationConfig } from "./replication/api/ReplicationConfig";
 import { mutationQueueModel, metadataModel } from "./replication/api/MetadataModels";
+import { Filter } from "./filters";
 
 const logger = createLogger("DataStore");
 // TODO disable logging before release
@@ -77,6 +78,13 @@ export class DataStore {
         this.storage.createStores();
         logger("Replication configuration was not provided. Replication will be disabled");
       }
+    }
+  }
+
+  public restartReplicator(model: Model, filter: Filter) {
+    if (this.replicator) {
+      model.applyReplicationFilter(filter);
+      this.replicator.resartReplicators(model);
     }
   }
 }

--- a/packages/datastore/datastore/src/Model.ts
+++ b/packages/datastore/datastore/src/Model.ts
@@ -98,6 +98,10 @@ export class Model<T = unknown> {
     return this.schema;
   }
 
+  public isLateInit(): boolean {
+    return this.schema.isLateInit();
+  }
+
   public query(filter?: Filter<T>) {
     if (!filter) { return this.storage.query(this.schema.getStoreName()); }
 

--- a/packages/datastore/datastore/src/Model.ts
+++ b/packages/datastore/datastore/src/Model.ts
@@ -362,9 +362,6 @@ export class Model<T = unknown> {
     const deltaConfig = this.replicationConfig?.delta as DeltaQueriesConfig;
     const liveConfig = this.replicationConfig?.liveupdates as LiveUpdatesConfig;
 
-    this.queries = buildGraphQLCRUDQueries(this);
-    this.subscriptionQueries = buildGraphQLCRUDSubscriptions(this);
-
     this.replicationConfig = {
       ...this.replicationConfig,
       delta: {
@@ -376,6 +373,9 @@ export class Model<T = unknown> {
         filter
       }
     };
+
+    this.queries = buildGraphQLCRUDQueries(this);
+    this.subscriptionQueries = buildGraphQLCRUDSubscriptions(this);
   }
 
   /**

--- a/packages/datastore/datastore/src/Model.ts
+++ b/packages/datastore/datastore/src/Model.ts
@@ -64,9 +64,9 @@ export class Model<T = unknown> {
   public replicationConfig: ModelReplicationConfig | undefined;
   public replication?: ModelChangeReplication;
   public changeEventStream: PushStream<StoreChangeEvent>;
-  private storage: LocalStorage;
   public queries: ReplicatorQueries;
   public subscriptionQueries: ReplicatorSubscriptions;
+  private storage: LocalStorage;
 
   constructor(
     schema: ModelSchema<T>,
@@ -376,14 +376,6 @@ export class Model<T = unknown> {
         filter
       }
     };
-  }
-
-  public startReplication() {
-
-  }
-
-  public stopReplication() {
-
   }
 
   /**

--- a/packages/datastore/datastore/src/Model.ts
+++ b/packages/datastore/datastore/src/Model.ts
@@ -3,7 +3,7 @@ import { StoreChangeEvent } from "./storage";
 import { ModelSchema } from "./ModelSchema";
 import { PushStream, ObservablePushStream } from "./utils/PushStream";
 import { Filter } from "./filters";
-import { ModelReplicationConfig } from "./replication/api/ReplicationConfig";
+import { DeltaQueriesConfig, LiveUpdatesConfig, ModelReplicationConfig } from "./replication/api/ReplicationConfig";
 import invariant from "tiny-invariant";
 import { ModelChangeReplication } from "./replication/mutations/MutationsQueue";
 import { v4 as uuidv4 } from "uuid";
@@ -353,6 +353,33 @@ export class Model<T = unknown> {
       input[primaryKey] = CLIENT_ID_PREFIX + uuidv4();
     }
     return input;
+  }
+
+  /**
+   * Late binding method for adding replication filters
+   * after Model setup.
+   * 
+   * i.e. setting a user filter after user login
+   * 
+   * @param filter to be applied to replication config
+   */
+  public applyReplicationFilter(filter: Filter) {
+    if (!this.replicationConfig) return;
+    
+    const deltaConfig = this.replicationConfig?.delta as DeltaQueriesConfig;
+    const liveConfig = this.replicationConfig?.liveupdates as LiveUpdatesConfig;
+
+    this.replicationConfig = {
+      ...this.replicationConfig,
+      delta: {
+        ...deltaConfig,
+        filter
+      },
+      liveupdates: {
+        ...liveConfig,
+        filter
+      }
+    }
   }
 }
 

--- a/packages/datastore/datastore/src/Model.ts
+++ b/packages/datastore/datastore/src/Model.ts
@@ -3,7 +3,7 @@ import { StoreChangeEvent } from "./storage";
 import { ModelSchema } from "./ModelSchema";
 import { PushStream, ObservablePushStream } from "./utils/PushStream";
 import { Filter } from "./filters";
-import { DeltaQueriesConfig, LiveUpdatesConfig, ModelReplicationConfig } from "./replication/api/ReplicationConfig";
+import { ModelReplicationConfig } from "./replication/api/ReplicationConfig";
 import invariant from "tiny-invariant";
 import { ModelChangeReplication } from "./replication/mutations/MutationsQueue";
 import { v4 as uuidv4 } from "uuid";
@@ -344,38 +344,6 @@ export class Model<T = unknown> {
     } catch (error) {
       logger("Error when processing subscription" + JSON.stringify(error));
     }
-  }
-
-  /**
-   * Late binding method for adding replication filters
-   * after Model setup.
-   *
-   * i.e. setting a user filter after user login
-   *
-   * @param filter to be applied to replication config
-   */
-  public applyReplicationFilter(filter: Filter) {
-    if (!this.replicationConfig) {
-      return;
-    }
-
-    const deltaConfig = this.replicationConfig?.delta as DeltaQueriesConfig;
-    const liveConfig = this.replicationConfig?.liveupdates as LiveUpdatesConfig;
-
-    this.replicationConfig = {
-      ...this.replicationConfig,
-      delta: {
-        ...deltaConfig,
-        filter
-      },
-      liveupdates: {
-        ...liveConfig,
-        filter
-      }
-    };
-
-    this.queries = buildGraphQLCRUDQueries(this);
-    this.subscriptionQueries = buildGraphQLCRUDSubscriptions(this);
   }
 
   /**

--- a/packages/datastore/datastore/src/ModelSchema.ts
+++ b/packages/datastore/datastore/src/ModelSchema.ts
@@ -49,6 +49,11 @@ export declare class ModelJsonSchema<T> {
    */
   namespace?: string;
   /**
+   * Flag for whether or not model replication
+   * should be initialised at a later point
+   */
+  lateInit?: boolean;
+  /**
    * Model version number
    */
   version?: number;
@@ -89,6 +94,7 @@ export declare class ModelJsonSchema<T> {
 export class ModelSchema<T = any>{
   private name: string;
   private namespace: string;
+  private lateInit: boolean;
   private primaryKey: string;
   private fields: Fields<T>;
   private encrypted: string[];
@@ -100,6 +106,7 @@ export class ModelSchema<T = any>{
     this.version = schema.version || 0;
     this.name = schema.name;
     this.namespace = schema.namespace || "user";
+    this.lateInit = schema.lateInit || false;
     this.fields = extractFields(schema);
     this.primaryKey = extractPrimary(this.fields, schema.primaryKey);
     this.indexes = extractIndexes(this.fields, schema.indexes);
@@ -138,6 +145,14 @@ export class ModelSchema<T = any>{
    */
   public getIndexes(): string[] {
     return this.indexes;
+  }
+
+  /**
+   * Indicator for if the replication should start
+   * at a later point
+   */
+  public isLateInit(): boolean {
+    return this.lateInit;
   }
 
   /**

--- a/packages/datastore/datastore/src/replication/queries/DeltaReplicator.ts
+++ b/packages/datastore/datastore/src/replication/queries/DeltaReplicator.ts
@@ -64,7 +64,7 @@ export class DeltaReplicator {
   }
 
   public stop() {
-    logger("Stopping replicator")
+    logger("Stopping replicator");
     clearInterval(this.activePullInterval);
     this.activePullInterval = undefined;
   }
@@ -109,7 +109,7 @@ export class DeltaReplicator {
         }
         const filter = { ...this.filter, lastSync };
         logger("filter", filter);
-        
+
         // const filter = Object.assign({}, this.filter, { lastSync });
         const result = await this.options.client.query(this.options.query, filter).toPromise();
         await this.processResult(result);

--- a/packages/datastore/datastore/src/replication/queries/DeltaReplicator.ts
+++ b/packages/datastore/datastore/src/replication/queries/DeltaReplicator.ts
@@ -49,7 +49,6 @@ export class DeltaReplicator {
         }
       }
     });
-
     this.applyFilter(this.options.config.filter);
   }
 
@@ -58,10 +57,14 @@ export class DeltaReplicator {
       this.filter = {};
       return;
     }
+    logger("Applying filter");
+    logger(filter);
     this.filter = convertFilterToGQLFilter(filter);
+    logger(this.filter);
   }
 
   public stop() {
+    logger("Stopping replicator")
     clearInterval(this.activePullInterval);
     this.activePullInterval = undefined;
   }
@@ -104,7 +107,10 @@ export class DeltaReplicator {
         if (!lastSync) {
           lastSync = "0";
         }
-        const filter = Object.assign({}, this.filter, { lastSync });
+        const filter = { ...this.filter, lastSync };
+        logger("filter", filter);
+        
+        // const filter = Object.assign({}, this.filter, { lastSync });
         const result = await this.options.client.query(this.options.query, filter).toPromise();
         await this.processResult(result);
       } catch (error) {

--- a/packages/datastore/datastore/src/replication/queries/DeltaReplicator.ts
+++ b/packages/datastore/datastore/src/replication/queries/DeltaReplicator.ts
@@ -8,6 +8,7 @@ import { LocalStorage } from "../../storage";
 import { Model } from "../../Model";
 import { NetworkIndicator } from "../network/NetworkIndicator";
 import { metadataModel, QueryMetadata } from "../api/MetadataModels";
+import { Filter } from "../..";
 
 
 const logger = createLogger("replicator-delta");
@@ -49,11 +50,15 @@ export class DeltaReplicator {
       }
     });
 
-    if (this.options.config.filter) {
-      this.filter = convertFilterToGQLFilter(this.options.config.filter);
-    } else {
+    this.applyFilter(this.options.config.filter);
+  }
+
+  public applyFilter(filter?: Filter) {
+    if (!filter) {
       this.filter = {};
+      return;
     }
+    this.filter = convertFilterToGQLFilter(filter);
   }
 
   public stop() {

--- a/packages/datastore/datastore/src/replication/subscriptions/SubscriptionReplicator.ts
+++ b/packages/datastore/datastore/src/replication/subscriptions/SubscriptionReplicator.ts
@@ -8,6 +8,7 @@ import { ReplicatorSubscriptions } from "./ReplicatorSubscriptions";
 import { convertFilterToGQLFilter } from "../utils/convertFilterToGQLFilter";
 import { pipe, subscribe } from "wonka";
 import { DocumentNode } from "graphql";
+import { subscriptionT } from "wonka/dist/types/src/Wonka_types.gen";
 
 const logger = createLogger("replicator-subscriptions");
 
@@ -27,6 +28,9 @@ export class SubscriptionReplicator {
   private options: SubscriptionReplicatorConfig;
   private filter: any;
   private wsConnected?: boolean;
+  private addSubscription?: subscriptionT;
+  private updateSubscription?: subscriptionT;
+  private deleteSubscription? : subscriptionT;
 
   constructor(options: SubscriptionReplicatorConfig) {
     this.options = options;
@@ -48,12 +52,21 @@ export class SubscriptionReplicator {
       }
 
       if (isConnected) {
-        this.subscribeToChanges(this.options.queries.new, CRUDEvents.ADD);
-        this.subscribeToChanges(this.options.queries.updated, CRUDEvents.UPDATE);
-        this.subscribeToChanges(this.options.queries.deleted, CRUDEvents.DELETE);
+        this.addSubscription = this.subscribeToChanges(this.options.queries.new, CRUDEvents.ADD);
+        this.updateSubscription = this.subscribeToChanges(this.options.queries.updated, CRUDEvents.UPDATE);
+        this.deleteSubscription = this.subscribeToChanges(this.options.queries.deleted, CRUDEvents.DELETE);
       }
-      // TODO Unsubscribe
+
+      return () => {
+        this.stop();
+      };
     });
+  }
+
+  public stop() {
+    this.addSubscription?.unsubscribe();
+    this.updateSubscription?.unsubscribe();
+    this.deleteSubscription?.unsubscribe();
   }
 
   private subscribeToChanges(query: DocumentNode, type: CRUDEvents) {

--- a/packages/datastore/datastore/src/replication/subscriptions/SubscriptionReplicator.ts
+++ b/packages/datastore/datastore/src/replication/subscriptions/SubscriptionReplicator.ts
@@ -43,7 +43,10 @@ export class SubscriptionReplicator {
       this.filter = {};
       return;
     }
+    logger("Applying filter");
+    logger(filter);
     this.filter = convertFilterToGQLFilter(filter);
+    logger(this.filter);
   }
 
   public async start() {
@@ -69,6 +72,7 @@ export class SubscriptionReplicator {
   }
 
   public stop() {
+    logger("Stopping subscriptions");
     this.addSubscription?.unsubscribe();
     this.updateSubscription?.unsubscribe();
     this.deleteSubscription?.unsubscribe();

--- a/packages/datastore/datastore/src/replication/subscriptions/SubscriptionReplicator.ts
+++ b/packages/datastore/datastore/src/replication/subscriptions/SubscriptionReplicator.ts
@@ -37,7 +37,7 @@ export class SubscriptionReplicator {
     this.options = options;
     this.applyFilter(this.options.config.filter);
   }
-  
+
   public applyFilter(filter?: Filter) {
     if (!filter) {
       this.filter = {};

--- a/packages/datastore/datastore/src/replication/subscriptions/SubscriptionReplicator.ts
+++ b/packages/datastore/datastore/src/replication/subscriptions/SubscriptionReplicator.ts
@@ -9,6 +9,7 @@ import { convertFilterToGQLFilter } from "../utils/convertFilterToGQLFilter";
 import { pipe, subscribe } from "wonka";
 import { DocumentNode } from "graphql";
 import { subscriptionT } from "wonka/dist/types/src/Wonka_types.gen";
+import { Filter } from "../..";
 
 const logger = createLogger("replicator-subscriptions");
 
@@ -34,11 +35,15 @@ export class SubscriptionReplicator {
 
   constructor(options: SubscriptionReplicatorConfig) {
     this.options = options;
-    if (this.options.config.filter) {
-      this.filter = convertFilterToGQLFilter(this.options.config.filter);
-    } else {
+    this.applyFilter(this.options.config.filter);
+  }
+  
+  public applyFilter(filter?: Filter) {
+    if (!filter) {
       this.filter = {};
+      return;
     }
+    this.filter = convertFilterToGQLFilter(filter);
   }
 
   public async start() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description
We need to provide the ability to start the replication at a later point in the app start up rather than only during initialisation.
At present, if we need to filter by a user id for example, there is no way to do this at a network level and we can only filter the results from the datastore. This will be an issue in a larger scale app.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
