### PR TITLE
fix(deps): fix failing dependency bumps

### DIFF
--- a/packages/datastore/datastore/tests/DataStore.test.ts
+++ b/packages/datastore/datastore/tests/DataStore.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  await new Promise((resolve, reject) => {
+  await new Promise((resolve: (value?: any) => void, reject) => {
     const del = indexedDB.deleteDatabase(DB_NAME);
     del.onsuccess = event => resolve();
     del.onblocked = event => resolve();

--- a/packages/offix/client/test/mock/MockStore.ts
+++ b/packages/offix/client/test/mock/MockStore.ts
@@ -11,14 +11,14 @@ export class MockStore {
   }
 
   public setItem(key: string, data: any): Promise<any> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve: (value?: any) => void, reject) => {
       this.data[key] = data;
       resolve();
     });
   }
 
   public removeItem(key: string): Promise<any> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve: (value?: any) => void, reject) => {
       delete this.data[key];
       resolve();
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

These are the errors due to which the checks are failing for PR #757:

```python
FAIL  packages/offix/client/test/conflictBase.test.ts
  ● Test suite failed to run

    packages/offix/client/test/mock/MockStore.ts:16:7 - error TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?

    16       resolve();
             ~~~~~~~~~

      node_modules/typescript/lib/lib.es2015.promise.d.ts:33:34
        33     new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~
        An argument for 'value' was not provided.
    packages/offix/client/test/mock/MockStore.ts:23:7 - error TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?

    23       resolve();
             ~~~~~~~~~

      node_modules/typescript/lib/lib.es2015.promise.d.ts:33:34
        33     new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~
        An argument for 'value' was not provided.

 FAIL  packages/datastore/datastore/tests/DataStore.test.ts
  ● Test suite failed to run

    packages/datastore/datastore/tests/DataStore.test.ts:55:30 - error TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?

    55     del.onsuccess = event => resolve();
                                    ~~~~~~~~~

      node_modules/typescript/lib/lib.es2015.promise.d.ts:33:34
        33     new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~
        An argument for 'value' was not provided.
    packages/datastore/datastore/tests/DataStore.test.ts:56:30 - error TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?

    56     del.onblocked = event => resolve();
                                    ~~~~~~~~~

      node_modules/typescript/lib/lib.es2015.promise.d.ts:33:34
        33     new <T>(executor: (resolve: (value: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
                                            ~~~~~~~~~~~~~~~~~~~~~~~~~
        An argument for 'value' was not provided.

```


I have added the necessary fixes which once merged, will ensure that all the tests for the PR #757 are passed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
