### PR TITLE
fix(conflictHandler): type check on object attribute to allow null value

### DIFF
--- a/packages/offix/conflicts-client/src/handler/ConflictHandler.ts
+++ b/packages/offix/conflicts-client/src/handler/ConflictHandler.ts
@@ -55,7 +55,7 @@ export class ConflictHandler {
     // Filter to send only original data from client
     const filteredData: any = {};
     for (const key of Object.keys(resolvedData)) {
-      if (this.options.client[key]) {
+      if (typeof(this.options.client[key])) {
         filteredData[key] = resolvedData[key];
       }
     }
@@ -71,7 +71,7 @@ export class ConflictHandler {
     }
     // calculate client diff
     for (const key of Object.keys(client)) {
-      if (base[key] && base[key] !== client[key]) {
+      if (typeof(base[key]) && base[key] !== client[key]) {
         if (!this.ignoredKeys.includes(key)) {
           this.clientDiff[key] = client[key];
         }
@@ -80,7 +80,7 @@ export class ConflictHandler {
 
     // calculate server diff
     for (const key of Object.keys(this.options.client)) {
-      if (base[key] && base[key] !== server[key]) {
+      if (typeof(base[key]) && base[key] !== server[key]) {
         if (!this.ignoredKeys.includes(key)) {
           this.serverDiff[key] = server[key];
           if (this.clientDiff[key]) {

--- a/packages/offix/conflicts-client/test/ConflictHandler.test.ts
+++ b/packages/offix/conflicts-client/test/ConflictHandler.test.ts
@@ -58,6 +58,21 @@ const conflictedSet = {
   }
 };
 
+const nullNonConflictSet = {
+  base: {
+    title:"a title",
+    description: null
+  },
+  client: {
+    title: "client updated title",
+    description: null
+  },
+  server: {
+    title: "a title",
+    description: "server updated description"
+  }
+};
+
 it("ensure conflicted is set to false", () => {
   const handler = new ConflictHandler({...nonConflictedSet, strategy, listener, objectState, operationName: "test"});
   expect(handler.conflicted).toBe(false);
@@ -88,6 +103,14 @@ it("ensure client data is persisted properly", () => {
   const handler = new ConflictHandler({...conflictedTitle, strategy, listener, objectState, operationName: "test"});
   const mergedData = handler.executeStrategy();
   expect(handler.conflicted).toBe(true);
+  expect(mergedData.title).toBe("client updated title");
+  expect(mergedData.description).toBe("server updated description");
+});
+
+it("ensure merged data is persisted properly with null attribute", () => {
+  const handler = new ConflictHandler({...nullNonConflictSet, strategy, listener, objectState, operationName: "test"});
+  const mergedData = handler.executeStrategy();
+  expect(handler.conflicted).toBe(false);
   expect(mergedData.title).toBe("client updated title");
   expect(mergedData.description).toBe("server updated description");
 });


### PR DESCRIPTION
The conflict handler failed to detect conflict when null attribute are present

### Description

The correction test `typeof(base[key])` object's attribute to check the existence of the attribute on object instead of just check `base[key]`

##### Checklist

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included

