### PR TITLE
Basic datastore id swap

### DIFF
--- a/examples/react-datastore/package.json
+++ b/examples/react-datastore/package.json
@@ -20,7 +20,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
-    "typescript": "~3.7.2",
+    "typescript": "4.1.5",
     "uniforms": "3.0.0-alpha.5",
     "uniforms-antd": "3.0.0-alpha.5",
     "uniforms-bridge-graphql": "3.0.0-alpha.5",
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@capacitor/cli": "^2.4.0",
     "@offix/cli": "0.2.1",
-    "graphback-cli": "0.16.0-beta1",
-    "graphql-serve": "0.16.0-beta1"
+    "graphback-cli": "1.1.1",
+    "graphql-serve": "1.1.1"
   }
 }

--- a/examples/react-datastore/src/App.tsx
+++ b/examples/react-datastore/src/App.tsx
@@ -4,10 +4,11 @@ import 'antd/dist/antd.css';
 
 import { useFindTodos } from './datastore/hooks';
 import { TodoList, AddTodo, Loading, Error, Header } from './components';
-import { TodoModel, UserModel } from './datastore/config';
+import { datastore, TodoModel, UserModel } from './datastore/config';
 
 function App() {
 
+  const [replicating, setReplicating] = useState<boolean>(true);
   const [addView, setAddView] = useState<boolean>(false);
   const  { loading, error, data, subscribeToUpdates } = useFindTodos();
 
@@ -17,9 +18,18 @@ function App() {
     // datastore.startReplication
     // the `startReplication` method accepts an
     // optional filter
-    TodoModel.startReplication()
-    UserModel.startReplication()
-  });
+    if (replicating) {
+      TodoModel.startReplication()
+      UserModel.startReplication()
+    }
+  }, [replicating]);
+
+  const toggleReplication = () => {
+    if (replicating) {
+      datastore.stopReplication()
+    } 
+    setReplicating(!replicating)
+  }
 
   useEffect(() => {
     const subscription = subscribeToUpdates();
@@ -47,6 +57,16 @@ function App() {
                   ghost
                 >
                   Add Todo
+                </Button>
+                <Button
+                  type="primary"
+                  onClick={() => toggleReplication()}
+                  danger
+                  ghost
+                >
+                  {
+                    replicating ? "Go Offline" : "Go Online"
+                  }
                 </Button>
               </>
             )

--- a/examples/react-datastore/src/App.tsx
+++ b/examples/react-datastore/src/App.tsx
@@ -4,7 +4,7 @@ import 'antd/dist/antd.css';
 
 import { useFindTodos } from './datastore/hooks';
 import { TodoList, AddTodo, Loading, Error, Header } from './components';
-import { datastore, TodoModel, UserModel } from './datastore/config';
+import { datastore } from './datastore/config';
 
 function App() {
 
@@ -19,8 +19,7 @@ function App() {
     // the `startReplication` method accepts an
     // optional filter
     if (replicating) {
-      TodoModel.startReplication()
-      UserModel.startReplication()
+      datastore.startReplication()
     }
   }, [replicating]);
 

--- a/examples/react-datastore/src/components/forms/EditTodo.tsx
+++ b/examples/react-datastore/src/components/forms/EditTodo.tsx
@@ -16,6 +16,7 @@ export const EditTodo = ({ todo, toggleEdit }: EditTodoProps) => {
       ...todo,
       title: todo.title,
       description: todo.description,
+      _version: todo._version ?? 2,
     })
     .then(() => toggleEdit())
     .catch((error: any) => {

--- a/examples/react-datastore/src/components/forms/EditTodo.tsx
+++ b/examples/react-datastore/src/components/forms/EditTodo.tsx
@@ -16,7 +16,7 @@ export const EditTodo = ({ todo, toggleEdit }: EditTodoProps) => {
       ...todo,
       title: todo.title,
       description: todo.description,
-      _version: todo._version ?? 2,
+      _version: todo._version ?? 1,
     })
     .then(() => toggleEdit())
     .catch((error: any) => {

--- a/examples/react-datastore/src/components/forms/ToggleTodo.tsx
+++ b/examples/react-datastore/src/components/forms/ToggleTodo.tsx
@@ -12,6 +12,7 @@ export function ToggleTodo({ todo }: ToggleTodoProps) {
   const handleUpdate = () => {
     editTodo({
       ...todo,
+      _version: todo._version ?? 2,
       completed: !todo.completed,
     })
       .then((res: any) => console.log("response", res))

--- a/examples/react-datastore/src/components/forms/ToggleTodo.tsx
+++ b/examples/react-datastore/src/components/forms/ToggleTodo.tsx
@@ -12,7 +12,7 @@ export function ToggleTodo({ todo }: ToggleTodoProps) {
   const handleUpdate = () => {
     editTodo({
       ...todo,
-      _version: todo._version ?? 2,
+      _version: todo._version ?? 1,
       completed: !todo.completed,
     })
       .then((res: any) => console.log("response", res))

--- a/packages/datastore/datastore/package.json
+++ b/packages/datastore/datastore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offix-datastore",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "repository": {

--- a/packages/datastore/datastore/src/replication/GraphQLReplicator.ts
+++ b/packages/datastore/datastore/src/replication/GraphQLReplicator.ts
@@ -93,6 +93,7 @@ export class GraphQLReplicator {
    *
    */
   public startReplication() {
+    this.mutationQueue?.startReplication();
     this.models.forEach(model => model.getReplicator()?.startReplication());
   }
 
@@ -101,6 +102,7 @@ export class GraphQLReplicator {
    * stop fetch replication at a global level
    */
   public stopReplication() {
+    this.mutationQueue?.stopReplication();
     this.models.forEach(model => model.getReplicator()?.stopReplication());
   }
 }

--- a/packages/datastore/datastore/src/replication/mutations/MutationsQueue.ts
+++ b/packages/datastore/datastore/src/replication/mutations/MutationsQueue.ts
@@ -12,7 +12,6 @@ import { GlobalReplicationConfig, MutationsConfig } from "../api/ReplicationConf
 import { buildGraphQLCRUDMutations } from "./buildGraphQLCRUDMutations";
 import invariant from "tiny-invariant";
 import { getFirstOperationData } from "../utils/getFirstOperationData";
-import Observable from "zen-observable";
 
 const logger = createLogger("replicator-mutationqueue");
 
@@ -59,7 +58,7 @@ export class MutationsReplicationQueue implements ModelChangeReplication {
   private processing: boolean;
   private replicating: boolean;
   private options: MutationReplicationOptions;
-  
+
   constructor(options: MutationReplicationOptions) {
     this.options = options;
     this.processing = false;
@@ -221,7 +220,7 @@ export class MutationsReplicationQueue implements ModelChangeReplication {
   /**
    * Helper method to flag that replication and start
    * processing the mutation queue.
-   * 
+   *
    */
   public startReplication() {
     this.replicating = true;
@@ -235,7 +234,7 @@ export class MutationsReplicationQueue implements ModelChangeReplication {
   public stopReplication() {
     this.replicating = false;
   }
-  
+
   private async getStoredMutations() {
     const data = await this.options.storage.queryById(mutationQueueModel.getStoreName(), "id", MUTATION_ROW_ID);
     if (data) {
@@ -339,7 +338,7 @@ export class MutationsReplicationQueue implements ModelChangeReplication {
           eventType: CRUDEvents.DELETE,
           data: [item.data]
         });
-        logger("Error occured while swapping client id: ", e.message)
+        logger("Error occured while swapping client id: ", e.message);
       }
     }
   }

--- a/packages/datastore/datastore/src/replication/mutations/MutationsQueue.ts
+++ b/packages/datastore/datastore/src/replication/mutations/MutationsQueue.ts
@@ -218,6 +218,24 @@ export class MutationsReplicationQueue implements ModelChangeReplication {
     this.processing = false;
   }
 
+  /**
+   * Helper method to flag that replication and start
+   * processing the mutation queue.
+   * 
+   */
+  public startReplication() {
+    this.replicating = true;
+    this.process();
+  }
+
+  /**
+   * Helper method to stop replication and stop the
+   * processing of the mutation queue.
+   */
+  public stopReplication() {
+    this.replicating = false;
+  }
+  
   private async getStoredMutations() {
     const data = await this.options.storage.queryById(mutationQueueModel.getStoreName(), "id", MUTATION_ROW_ID);
     if (data) {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -59,7 +59,9 @@
       {
         "type": "category",
         "label": "Replication",
-        "items": []
+        "items": [
+          "datastore/replication"
+        ]
       },
       {
         "type": "category",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description
- This is PR restores a basic id swap. It will remove the object with the client ID from the store
  - This won't replace items in the mutation queue that have the client id
- The mutation queue was missing the ability to stop and restart the queue processor
- Added manual stop and stop for replication in the example app

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
